### PR TITLE
fix(sdk): resolve document initialization and integration test failures

### DIFF
--- a/sdk/src/__tests__/integration/sync.test.ts
+++ b/sdk/src/__tests__/integration/sync.test.ts
@@ -7,7 +7,7 @@
 import { beforeEach, afterEach, describe, expect, it } from 'vitest'
 import { SyncKit } from '../../synckit'
 import { MemoryStorage } from '../../storage'
-import type { WebSocketMessage } from '../../websocket/client'
+import type { WebSocketMessage, MessageType } from '../../websocket/client'
 
 // Mock CloseEvent if not available
 if (typeof CloseEvent === 'undefined') {
@@ -25,8 +25,7 @@ if (typeof CloseEvent === 'undefined') {
 // Mock WebSocket for testing
 class MockWebSocket {
   static instances: MockWebSocket[] = []
-
-  readyState = WebSocket.CONNECTING
+  readyState: number = WebSocket.CONNECTING
   binaryType: BinaryType = 'arraybuffer'
   onopen: ((event: Event) => void) | null = null
   onclose: ((event: CloseEvent) => void) | null = null
@@ -75,8 +74,7 @@ class MockWebSocket {
       this.onmessage(new MessageEvent('message', { data: encoded }))
     }
   }
-
-  onMessageType(type: string, handler: (payload: any) => void): void {
+  onMessageType(type: MessageType, handler: (payload: any) => void): void {
     this.messageHandlers.set(type, handler)
   }
 
@@ -112,8 +110,8 @@ class MockWebSocket {
     }
   }
 
-  private getTypeCode(type: string): number {
-    const map: Record<string, number> = {
+  private getTypeCode(type: MessageType): number {
+    const map: Record<MessageType, number> = {
       auth: 0x01,
       auth_success: 0x02,
       auth_error: 0x03,
@@ -130,8 +128,8 @@ class MockWebSocket {
     return map[type] || 0xff
   }
 
-  private getTypeName(code: number): string {
-    const map: Record<number, string> = {
+  private getTypeName(code: number): MessageType {
+    const map: Record<number, MessageType> = {
       0x01: 'auth',
       0x02: 'auth_success',
       0x03: 'auth_error',
@@ -145,7 +143,7 @@ class MockWebSocket {
       0x31: 'pong',
       0xff: 'error',
     }
-    return map[code] || 'error'
+    return (map[code] as MessageType) || 'error'
   }
 }
 

--- a/sdk/src/__tests__/performance/benchmarks.test.ts
+++ b/sdk/src/__tests__/performance/benchmarks.test.ts
@@ -11,8 +11,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { SyncKit } from '../../synckit'
 import { MemoryStorage } from '../../storage'
-import { WebSocketClient } from '../../websocket/client'
-import type { WebSocketMessage } from '../../websocket/client'
+import type { WebSocketMessage, MessageType } from '../../websocket/client'
 import { OfflineQueue } from '../../sync/queue'
 
 // Performance measurement utility
@@ -343,13 +342,13 @@ function getTypeCode(type: string): number {
   return map[type] || 0xff
 }
 
-function getTypeName(code: number): string {
-  const map: Record<number, string> = {
+function getTypeName(code: number): MessageType {
+  const map: Record<number, MessageType> = {
     0x01: 'auth',
     0x20: 'delta',
     0x21: 'ack',
     0x30: 'ping',
     0x31: 'pong',
   }
-  return map[code] || 'error'
+  return (map[code] as MessageType) || 'error'
 }

--- a/sdk/src/__tests__/sync/manager.test.ts
+++ b/sdk/src/__tests__/sync/manager.test.ts
@@ -6,10 +6,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   SyncManager,
   type SyncableDocument,
-  type DocumentSyncState,
 } from '../../sync/manager'
-import type { WebSocketClient, MessageType } from '../../websocket/client'
-import type { OfflineQueue, Operation, VectorClock } from '../../sync/queue'
+import type { MessageType } from '../../websocket/client'
+import type { Operation, VectorClock } from '../../sync/queue'
 import type { StorageAdapter } from '../../types'
 
 // Mock Storage
@@ -52,7 +51,7 @@ class MockWebSocketClient {
     }
   }
 
-  send(message: any): void {
+  send(_message: any): void {
     // Mock implementation
   }
 
@@ -90,14 +89,14 @@ class MockWebSocketClient {
 // Mock Offline Queue
 class MockOfflineQueue {
   async init(): Promise<void> {}
-  async enqueue(operation: Operation): Promise<void> {}
-  async replay(sender: (op: Operation) => Promise<void>): Promise<number> {
+  async enqueue(_operation: Operation): Promise<void> {}
+  async replay(_sender: (op: Operation) => Promise<void>): Promise<number> {
     return 0
   }
   getStats() {
     return { size: 0, replaying: 0, failed: 0, oldestOperation: null }
   }
-  onChange(callback: any): () => void {
+  onChange(_callback: any): () => void {
     return () => {}
   }
 }
@@ -123,7 +122,7 @@ class MockDocument implements SyncableDocument {
     this.clock = { ...clock }
   }
 
-  applyRemoteOperation(operation: Operation): void {
+  applyRemoteOperation(_operation: Operation): void {
     // Mock implementation
   }
 }
@@ -266,7 +265,7 @@ describe('SyncManager', () => {
       // Simulate ACK
       setTimeout(() => {
         // Extract messageId from the send call
-        const sendCall = sendSpy.mock.calls[0]
+        const sendCall = sendSpy.mock.calls[0]!
         const messageId = sendCall[0].payload.messageId
         websocket.trigger('ack', { messageId })
       }, 10)

--- a/sdk/src/__tests__/websocket/client.test.ts
+++ b/sdk/src/__tests__/websocket/client.test.ts
@@ -2,7 +2,7 @@
  * WebSocket Client Unit Tests
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import {
   WebSocketClient,
   WebSocketError,
@@ -37,13 +37,13 @@ class MockWebSocket {
     }, 10)
   }
 
-  send(data: any): void {
+  send(_data: any): void {
     if (this.readyState !== MockWebSocket.OPEN) {
       throw new Error('WebSocket is not open')
     }
     // Echo back (for testing)
     if (this.onmessage) {
-      this.onmessage({ data })
+      this.onmessage({ data: _data })
     }
   }
 
@@ -190,7 +190,7 @@ describe('WebSocketClient', () => {
         timestamp: Date.now(),
       }
 
-      let receivedMessage: WebSocketMessage | null = null
+      let receivedMessage: any = null
       client.on('delta', (payload) => {
         receivedMessage = { type: 'delta', payload, timestamp: Date.now() }
       })
@@ -201,8 +201,8 @@ describe('WebSocketClient', () => {
       await new Promise((resolve) => setTimeout(resolve, 50))
 
       expect(receivedMessage).not.toBeNull()
-      expect(receivedMessage?.type).toBe('delta')
-      expect(receivedMessage?.payload).toEqual(originalMessage.payload)
+      expect((receivedMessage as any)?.type).toBe('delta')
+      expect((receivedMessage as any)?.payload).toEqual(originalMessage.payload)
     })
 
     it('handles all message types', () => {
@@ -480,7 +480,7 @@ describe('WebSocketClient', () => {
           }, 10)
         }
 
-        send(data: any): void {
+        send(_data: any): void {
           throw new Error('Not connected')
         }
 
@@ -591,7 +591,7 @@ describe('WebSocketClient', () => {
           }, 10)
         }
 
-        send(data: any): void {
+        send(_data: any): void {
           throw new Error('Not connected')
         }
 
@@ -636,7 +636,7 @@ describe('WebSocketClient', () => {
           }, 10)
         }
 
-        send(data: any): void {
+        send(_data: any): void {
           throw new Error('Not connected')
         }
 


### PR DESCRIPTION
## Description

Fixes and stabilizes SDK integration tests and document initialization to ensure deterministic test behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Test update
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update (no functional changes)
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔧 Build/CI update

## Related Issues

None.

## Changes Made

- `26b4cca` fix(tests): update MockWebSocket and call document init() explicitly for stability of integration and performance tests
  - Ensure documents are initialized explicitly in tests to avoid intermittent failures during wasm-backed state initialization.
- `db1069c` fix(tests): improve delta acknowledgment handling in integration tests
  - Make ack handling asynchronous and use the correct `messageId` field so `waitForAck()` registers pending ACKs reliably.
- `5de0e9c` fix(tests): close mock WebSocket connections after each test and ensure LWW ordering with higher clock values
  - Close and clear `MockWebSocket` instances in `afterEach` to avoid cross-test leakage; use increasing vector-clock values so LWW conflict resolution behaves deterministically in tests.
- `62ccdf1`fix(tests): resolve typescript linting issues 

## Testing

- Ran full SDK test suite locally:

  ```bash
  cd sdk
  npx vitest run
  ```

- Result: `6 test files, 100 tests` — all passing locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the tests
- [x] New and existing unit/integration tests pass locally with my changes

## Screenshots / Demo

N/A

## Additional Context

This PR initially included a breaking change in the document API, and numerous downstream changes as a result. Since commit `408837d429a15f4f6403ca5fdb00fcb4b0323a2f` this was reverted and now only the tests themselves have been modified. It focuses strictly on test stability and related small test harness changes; it does not introduce API changes to the runtime library.

This PR should ideally be squashed to exclude the unnecessary noise and confusion from the earlier commits.
