### PR TITLE
feat(stress-test): add 48-day production stress test infrastructure

### DIFF
--- a/stress-test/README.md
+++ b/stress-test/README.md
@@ -1,0 +1,330 @@
+# SyncKit 48-Day Production Stress Test
+
+**Purpose:** Validate v0.3.0 stability under extended production load before launch.
+
+**Timeline:** January 4, 2026 - February 21, 2026 (48 days)
+
+**Status:** 🚧 Setting up infrastructure
+
+---
+
+## Overview
+
+This stress test validates:
+1. **Memory leak fixes** from PR #56 (4 leaks patched)
+2. **OPFS storage adapter** performance under sustained load
+3. **WebSocket connection stability** over extended periods
+4. **Server-side resource management** (connections, batching, awareness)
+5. **Client-side memory stability** in browser environments
+
+## Test Methodology
+
+### Client Behavior
+- **Operations:** 1 operation/second (86,400 ops/day)
+- **Operation Mix:**
+  - 40% Creates (new todos)
+  - 30% Updates (toggle completed)
+  - 15% Deletes (remove todos)
+  - 15% Reads (list all todos)
+- **Storage:** OPFS (Origin Private File System)
+- **Connection:** WebSocket with automatic reconnection
+- **Monitoring:** Memory snapshots every minute
+
+### Expected Totals (48 days)
+- **Total Operations:** ~4,147,200
+- **Documents Created:** ~1,658,880
+- **Documents Updated:** ~1,244,160
+- **Documents Deleted:** ~622,080
+
+### Success Criteria
+- ✅ Zero memory leaks (stable heap usage)
+- ✅ >99% operation success rate
+- ✅ <10 unexpected disconnections
+- ✅ No data corruption or loss
+- ✅ Client remains responsive throughout
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│   Stress Test Client (Browser)              │
+│   - OPFS Storage                            │
+│   - WebSocket Connection                    │
+│   - Metrics Dashboard                       │
+└─────────────┬───────────────────────────────┘
+              │ WSS (WebSocket Secure)
+              │
+┌─────────────▼───────────────────────────────┐
+│   SyncKit Server (Fly.io)                   │
+│   - Memory Leak Fixes Applied               │
+│   - LRU Cache (1000 docs)                   │
+│   - Batch Timer Cleanup                     │
+│   - Event Handler Cleanup                   │
+└─────────────────────────────────────────────┘
+```
+
+---
+
+## Quick Start
+
+### 1. Deploy Server to Fly.io
+
+```bash
+cd server/typescript
+
+# Login to Fly.io
+fly auth login
+
+# Create app for stress test
+fly launch --name synckit-stress-test --region sjc
+
+# Set secrets
+fly secrets set JWT_SECRET=$(openssl rand -base64 32)
+
+# Deploy
+fly deploy
+```
+
+### 2. Run Stress Test Client
+
+```bash
+cd stress-test/client
+
+# Install dependencies
+npm install
+
+# Configure server URL
+cp .env.example .env
+# Edit .env and set VITE_SERVER_URL=wss://synckit-stress-test.fly.dev
+
+# Start client
+npm run dev
+```
+
+### 3. Access Dashboard
+
+Open browser to http://localhost:3000
+
+The stress test will:
+1. Connect to the Fly.io server
+2. Initialize OPFS storage
+3. Start performing operations (1/second)
+4. Display real-time metrics
+
+### 4. Keep Browser Tab Open
+
+**IMPORTANT:** Keep the browser tab open and active for the full 48 days.
+
+**Tips:**
+- Use a dedicated browser profile
+- Disable sleep mode on the computer
+- Use browser extension to prevent tab from sleeping
+- Check metrics daily via the dashboard
+
+---
+
+## Monitoring
+
+### Real-Time Dashboard
+
+The client dashboard displays:
+- ⏱️ **Uptime** (days, hours, minutes)
+- 📈 **Total Operations** (running count)
+- ✅ **Success Rate** (percentage)
+- ❌ **Failed Operations** (count)
+- 🔄 **Reconnects** (connection drops)
+- 💾 **Memory Usage** (heap size in MB)
+- 📊 **Progress** (% of 48 days completed)
+
+### Exporting Metrics
+
+Click "Export Metrics" button to download JSON file with:
+- Full operation history
+- Memory usage timeline (last 24 hours)
+- Error logs (last 100)
+- Timestamps and statistics
+
+### Server-Side Monitoring
+
+```bash
+# View server logs
+fly logs -a synckit-stress-test
+
+# Check server status
+fly status -a synckit-stress-test
+
+# Monitor resource usage
+fly dashboard -a synckit-stress-test
+```
+
+---
+
+## Files
+
+```
+stress-test/
+├── client/
+│   ├── index.html          # Dashboard UI
+│   ├── stress-test.ts      # Client implementation
+│   ├── package.json        # Dependencies
+│   ├── vite.config.js      # Dev server config
+│   └── .env.example        # Server URL config
+├── fly.toml                # Fly.io deployment config (custom)
+└── README.md               # This file
+```
+
+---
+
+## Expected Results
+
+### Memory Baseline (From PR #56 Audit)
+
+**Leaks Fixed:**
+1. **Batch Timers** - Cleared on disconnect ✅
+2. **Event Handlers** - Explicit cleanup ✅
+3. **Documents Cache** - LRU eviction (1000 docs) ✅
+4. **Awareness States** - Removed when empty ✅
+
+**Expected Behavior:**
+- Client heap should stabilize after initial ramp-up (~100-200 MB)
+- Server memory should remain stable with LRU eviction
+- No unbounded growth in any data structures
+
+### Performance Baseline (From BENCHMARK_RESULTS.md)
+
+**OPFS Performance:**
+- Write Small (10 items): 0.52ms avg
+- Write Medium (100 items): 1.52ms avg
+- Write Large (1000 items): 5.30ms avg
+- Read: 0.68ms avg
+- Delete: 0.44ms avg
+
+**Target:** Operations should maintain these latencies throughout 48 days.
+
+---
+
+## Troubleshooting
+
+### Client Disconnects Frequently
+
+**Check:**
+1. Fly.io server status: `fly status -a synckit-stress-test`
+2. Server logs for errors: `fly logs -a synckit-stress-test`
+3. Network connectivity on client machine
+4. Browser console for WebSocket errors
+
+**Fix:**
+- Server may have crashed (check logs, redeploy if needed)
+- Network issues (check firewall, proxy settings)
+- Fly.io may have scaled down (increase min_machines_running in fly.toml)
+
+### Memory Usage Growing Unbounded
+
+**This indicates a memory leak!**
+
+**Action:**
+1. Export metrics immediately (click "Export Metrics")
+2. Save browser DevTools heap snapshot
+3. File GitHub issue with:
+   - Exported metrics JSON
+   - Heap snapshot
+   - Browser version
+   - Time when growth started
+
+### Operations Failing
+
+**Check:**
+- Success rate in dashboard
+- Error logs in console
+- Server logs: `fly logs -a synckit-stress-test`
+
+**Common Causes:**
+- Server overload (scale up resources)
+- OPFS storage quota exceeded (check quota in DevTools)
+- Network timeouts (increase timeout config)
+
+---
+
+## Cost Estimate (Fly.io)
+
+**Server Resources:**
+- CPU: 1 shared vCPU
+- Memory: 512MB
+- Region: San Jose (sjc)
+
+**Expected Cost:** ~$5-10/month
+
+**Notes:**
+- Fly.io free tier includes $5/month credit
+- Stress test should cost <$10 for 48 days
+- No database or Redis needed for this test (using OPFS client-side)
+
+---
+
+## What Happens After 48 Days?
+
+### If Successful ✅
+
+**Criteria Met:**
+- Memory stable (no leaks)
+- >99% success rate
+- <10 disconnections
+
+**Next Steps:**
+1. Export final metrics
+2. Create completion report
+3. Merge to main branch
+4. Prepare v0.3.0 launch
+5. Publish results as blog post
+
+### If Issues Found ❌
+
+**Action Plan:**
+1. Export metrics and logs
+2. Identify root cause
+3. Fix issues in new PR
+4. Restart 48-day test
+5. Delay v0.3.0 launch if needed
+
+**Priority:** Stability > Launch Date
+
+---
+
+## Development Notes
+
+### Why 48 Days?
+
+- Validates memory leaks don't manifest over time
+- Tests connection stability through network variations
+- Simulates real-world long-running client sessions
+- Proves production readiness
+
+### Why OPFS?
+
+- Benchmarks show 4-30x faster than IndexedDB
+- Immune to Safari's 7-day eviction policy
+- Client-side storage (no server database needed for test)
+- Tests the new v0.3.0 feature directly
+
+### Why Browser Client?
+
+- Real production environment (not synthetic load)
+- Tests actual SDK code users will run
+- Validates browser memory management
+- Easy to monitor with DevTools
+
+---
+
+## Support
+
+- **Issues:** https://github.com/Dancode-188/synckit/issues
+- **Discussion:** https://github.com/Dancode-188/synckit/discussions
+- **Server Logs:** `fly logs -a synckit-stress-test`
+
+---
+
+**Last Updated:** January 4, 2026
+**Test Status:** 🚧 Infrastructure Setup Phase
+**Expected Start:** January 4, 2026 (Today!)

--- a/stress-test/client-node/.dockerignore
+++ b/stress-test/client-node/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+*.log
+.env
+.DS_Store
+metrics

--- a/stress-test/client-node/.env.example
+++ b/stress-test/client-node/.env.example
@@ -1,0 +1,5 @@
+# SyncKit Server URL (WebSocket)
+SERVER_URL=wss://synckit-stress-test.fly.dev
+
+# Metrics directory (optional, defaults to ./metrics)
+METRICS_DIR=./metrics

--- a/stress-test/client-node/Dockerfile
+++ b/stress-test/client-node/Dockerfile
@@ -1,0 +1,50 @@
+# SyncKit Stress Test Client - Node.js
+# Runs 24/7 on Fly.io for 48-day stress test
+
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy SDK first (local dependency)
+COPY ../../sdk /app/sdk
+WORKDIR /app/sdk
+RUN npm install && npm run build
+
+# Copy stress test client
+WORKDIR /app/client
+COPY package*.json ./
+COPY tsconfig.json ./
+COPY src ./src
+
+# Install dependencies and build
+RUN npm install
+RUN npm run build
+
+# Production image
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Copy SDK
+COPY --from=builder /app/sdk /app/sdk
+
+# Copy built client
+COPY --from=builder /app/client/dist ./dist
+COPY --from=builder /app/client/package*.json ./
+COPY --from=builder /app/client/node_modules ./node_modules
+
+# Create metrics directory
+RUN mkdir -p /app/metrics
+
+# Run as non-root user
+RUN addgroup -g 1001 -S nodejs && \
+    adduser -S nodejs -u 1001
+RUN chown -R nodejs:nodejs /app
+USER nodejs
+
+# Set environment
+ENV NODE_ENV=production
+ENV METRICS_DIR=/app/metrics
+
+# Start the stress test
+CMD ["node", "dist/index.js"]

--- a/stress-test/client-node/fly.toml
+++ b/stress-test/client-node/fly.toml
@@ -1,0 +1,56 @@
+# SyncKit Stress Test Client - Fly.io Configuration
+# 48-day production stress test (runs 24/7)
+
+app = "synckit-stress-test-client"
+primary_region = "sjc"  # San Jose, CA
+
+# Build configuration
+[build]
+  dockerfile = "Dockerfile"
+
+# Environment variables
+[env]
+  NODE_ENV = "production"
+  METRICS_DIR = "/app/metrics"
+
+# HTTP service (for health checks)
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+
+  # Keep client running continuously
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+
+  # Health check endpoint (optional - we'll add a simple HTTP server)
+  [[services.http_checks]]
+    interval = "60s"
+    timeout = "10s"
+    grace_period = "30s"
+    method = "GET"
+    path = "/health"
+    protocol = "http"
+
+  # HTTP handlers
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+
+# Resource allocation - minimal for cost efficiency
+[vm]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 256  # Tiny machine, just for stress testing
+
+# Persistent storage for metrics
+[mounts]
+  source = "stress_test_metrics"
+  destination = "/app/metrics"
+
+# Deploy command:
+# cd stress-test/client-node
+# fly apps create synckit-stress-test-client --region sjc
+# fly volumes create stress_test_metrics --region sjc --size 1
+# fly secrets set SERVER_URL=wss://synckit-stress-test.fly.dev
+# fly deploy

--- a/stress-test/client-node/package.json
+++ b/stress-test/client-node/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@synckit-stress-test/client-node",
+  "version": "0.3.0",
+  "description": "48-day production stress test client for SyncKit v0.3.0 (Node.js)",
+  "type": "module",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@synckit-js/sdk": "file:../../sdk"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/stress-test/client-node/src/index.ts
+++ b/stress-test/client-node/src/index.ts
@@ -1,0 +1,433 @@
+/**
+ * SyncKit 48-Day Production Stress Test - Node.js Version
+ *
+ * Runs as a server-side service on Fly.io (24/7 operation).
+ * Tests memory leak fixes, WebSocket stability, and server performance.
+ *
+ * Target: Run continuously for 48 days generating sustained load
+ */
+
+import { SyncKit } from '@synckit-js/sdk';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as http from 'http';
+
+interface TodoItem {
+  id: string;
+  title: string;
+  completed: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface StressTestMetrics {
+  startTime: number;
+  totalOperations: number;
+  successfulOperations: number;
+  failedOperations: number;
+  reconnects: number;
+  errors: string[];
+  lastMemorySnapshot: {
+    timestamp: number;
+    heapUsed: number;
+    heapTotal: number;
+    external: number;
+    rss: number;
+  } | null;
+}
+
+class NodeStressTestClient {
+  private synckit: SyncKit | null = null;
+  private metrics: StressTestMetrics;
+  private isRunning = false;
+  private intervalId: NodeJS.Timeout | null = null;
+  private metricsIntervalId: NodeJS.Timeout | null = null;
+  private metricsFilePath: string;
+
+  private readonly SERVER_URL: string;
+  private readonly DOCUMENT_ID = 'stress-test-todos';
+  private readonly OPERATION_INTERVAL_MS = 1000; // 1 operation per second
+  private readonly METRICS_INTERVAL_MS = 60000; // Report metrics every minute
+  private readonly MAX_ERRORS_LOGGED = 100;
+
+  constructor(serverUrl: string, metricsDir: string = './metrics') {
+    this.SERVER_URL = serverUrl;
+    this.metricsFilePath = path.join(metricsDir, 'stress-test-metrics.json');
+
+    // Ensure metrics directory exists
+    if (!fs.existsSync(metricsDir)) {
+      fs.mkdirSync(metricsDir, { recursive: true });
+    }
+
+    this.metrics = {
+      startTime: Date.now(),
+      totalOperations: 0,
+      successfulOperations: 0,
+      failedOperations: 0,
+      reconnects: 0,
+      errors: [],
+      lastMemorySnapshot: null,
+    };
+
+    // Restore metrics from file if available
+    this.loadMetricsFromFile();
+  }
+
+  async init(): Promise<void> {
+    console.log('🚀 Initializing Node.js stress test client...');
+    console.log(`🔗 Server: ${this.SERVER_URL}`);
+
+    try {
+      // Initialize SyncKit with memory storage (no persistence needed for stress test)
+      this.synckit = new SyncKit({
+        clientId: 'stress-test-node-' + Math.random().toString(36).substring(2, 9),
+        storage: 'memory', // Use memory storage for Node.js
+        serverUrl: this.SERVER_URL,
+      });
+
+      await this.synckit.init();
+      console.log('✅ SyncKit initialized and connected to server');
+    } catch (error) {
+      console.error('❌ Initialization failed:', error);
+      throw error;
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this.isRunning) {
+      console.warn('⚠️  Stress test is already running');
+      return;
+    }
+
+    this.isRunning = true;
+    console.log('\n🏁 Starting 48-day stress test...');
+    console.log(`📊 Target: ~4,147,200 operations over 48 days`);
+    console.log(`⏱️  Rate: 1 operation/second (86,400 ops/day)`);
+    console.log('');
+
+    // Start operation loop
+    this.intervalId = setInterval(() => {
+      this.performOperation().catch(err => {
+        console.error('Operation failed:', err);
+      });
+    }, this.OPERATION_INTERVAL_MS);
+
+    // Start metrics reporting loop
+    this.metricsIntervalId = setInterval(() => {
+      this.reportMetrics();
+      this.saveMetricsToFile();
+    }, this.METRICS_INTERVAL_MS);
+
+    // Perform first operation immediately
+    await this.performOperation();
+  }
+
+  stop(): void {
+    console.log('🛑 Stopping stress test...');
+    this.isRunning = false;
+
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+
+    if (this.metricsIntervalId !== null) {
+      clearInterval(this.metricsIntervalId);
+      this.metricsIntervalId = null;
+    }
+
+    this.saveMetricsToFile();
+    console.log('✅ Stress test stopped');
+  }
+
+  private async performOperation(): Promise<void> {
+    if (!this.synckit) {
+      throw new Error('SyncKit not initialized');
+    }
+
+    this.metrics.totalOperations++;
+
+    // Weighted random operation selection
+    const rand = Math.random();
+    let operation: string;
+
+    if (rand < 0.40) operation = 'create';       // 40%
+    else if (rand < 0.70) operation = 'update';  // 30%
+    else if (rand < 0.85) operation = 'delete';  // 15%
+    else operation = 'read';                      // 15%
+
+    try {
+      switch (operation) {
+        case 'create':
+          await this.createTodo();
+          break;
+        case 'update':
+          await this.updateTodo();
+          break;
+        case 'delete':
+          await this.deleteTodo();
+          break;
+        case 'read':
+          await this.readTodos();
+          break;
+      }
+
+      this.metrics.successfulOperations++;
+    } catch (error) {
+      this.metrics.failedOperations++;
+      this.logError(`${operation} failed: ${error}`);
+    }
+  }
+
+  private async createTodo(): Promise<void> {
+    if (!this.synckit) throw new Error('SyncKit not initialized');
+
+    const doc = this.synckit.document<{ todos: TodoItem[] }>(this.DOCUMENT_ID);
+    await doc.init();
+
+    const currentData = doc.get();
+    const todos = currentData.todos || [];
+
+    const newTodo: TodoItem = {
+      id: `todo-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+      title: `Stress test todo #${this.metrics.totalOperations}`,
+      completed: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    await doc.set('todos', [...todos, newTodo]);
+  }
+
+  private async updateTodo(): Promise<void> {
+    if (!this.synckit) throw new Error('SyncKit not initialized');
+
+    const doc = this.synckit.document<{ todos: TodoItem[] }>(this.DOCUMENT_ID);
+    await doc.init();
+
+    const currentData = doc.get();
+    const todos = currentData.todos || [];
+
+    if (todos.length === 0) {
+      // No todos to update, create one instead
+      await this.createTodo();
+      return;
+    }
+
+    // Toggle random todo
+    const randomIndex = Math.floor(Math.random() * todos.length);
+    const updatedTodos = todos.map((todo, idx) => {
+      if (idx === randomIndex) {
+        return {
+          ...todo,
+          completed: !todo.completed,
+          updatedAt: Date.now(),
+        };
+      }
+      return todo;
+    });
+
+    await doc.set('todos', updatedTodos);
+  }
+
+  private async deleteTodo(): Promise<void> {
+    if (!this.synckit) throw new Error('SyncKit not initialized');
+
+    const doc = this.synckit.document<{ todos: TodoItem[] }>(this.DOCUMENT_ID);
+    await doc.init();
+
+    const currentData = doc.get();
+    const todos = currentData.todos || [];
+
+    if (todos.length === 0) {
+      // No todos to delete
+      return;
+    }
+
+    // Delete random todo
+    const randomIndex = Math.floor(Math.random() * todos.length);
+    const updatedTodos = todos.filter((_, idx) => idx !== randomIndex);
+
+    await doc.set('todos', updatedTodos);
+  }
+
+  private async readTodos(): Promise<void> {
+    if (!this.synckit) throw new Error('SyncKit not initialized');
+
+    const doc = this.synckit.document<{ todos: TodoItem[] }>(this.DOCUMENT_ID);
+    await doc.init();
+
+    const currentData = doc.get();
+    const todos = currentData.todos || [];
+
+    // Just read the data (already fetched by doc.get())
+    // Logging suppressed to reduce noise
+  }
+
+  private reportMetrics(): void {
+    const now = Date.now();
+    const uptime = now - this.metrics.startTime;
+    const days = Math.floor(uptime / (1000 * 60 * 60 * 24));
+    const hours = Math.floor((uptime % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+    const minutes = Math.floor((uptime % (1000 * 60 * 60)) / (1000 * 60));
+
+    const successRate = this.metrics.totalOperations > 0
+      ? ((this.metrics.successfulOperations / this.metrics.totalOperations) * 100).toFixed(2)
+      : '0.00';
+
+    console.log('\n📊 === Stress Test Metrics ===');
+    console.log(`⏱️  Uptime: ${days}d ${hours}h ${minutes}m`);
+    console.log(`📈 Total Operations: ${this.metrics.totalOperations.toLocaleString()}`);
+    console.log(`✅ Successful: ${this.metrics.successfulOperations.toLocaleString()} (${successRate}%)`);
+    console.log(`❌ Failed: ${this.metrics.failedOperations.toLocaleString()}`);
+    console.log(`🔄 Reconnects: ${this.metrics.reconnects}`);
+
+    // Memory snapshot (Node.js)
+    const memUsage = process.memoryUsage();
+    const heapUsedMB = (memUsage.heapUsed / 1024 / 1024).toFixed(2);
+    const heapTotalMB = (memUsage.heapTotal / 1024 / 1024).toFixed(2);
+    const rssMB = (memUsage.rss / 1024 / 1024).toFixed(2);
+
+    console.log(`💾 Memory: ${heapUsedMB} MB / ${heapTotalMB} MB (RSS: ${rssMB} MB)`);
+
+    // Store memory snapshot
+    this.metrics.lastMemorySnapshot = {
+      timestamp: now,
+      heapUsed: memUsage.heapUsed,
+      heapTotal: memUsage.heapTotal,
+      external: memUsage.external,
+      rss: memUsage.rss,
+    };
+
+    console.log('========================\n');
+  }
+
+  private logError(message: string): void {
+    const errorMsg = `[${new Date().toISOString()}] ${message}`;
+    this.metrics.errors.push(errorMsg);
+
+    // Keep only last 100 errors
+    if (this.metrics.errors.length > this.MAX_ERRORS_LOGGED) {
+      this.metrics.errors = this.metrics.errors.slice(-this.MAX_ERRORS_LOGGED);
+    }
+
+    console.error('❌', errorMsg);
+  }
+
+  private saveMetricsToFile(): void {
+    try {
+      fs.writeFileSync(
+        this.metricsFilePath,
+        JSON.stringify(this.metrics, null, 2),
+        'utf-8'
+      );
+    } catch (error) {
+      console.warn('Failed to save metrics to file:', error);
+    }
+  }
+
+  private loadMetricsFromFile(): void {
+    try {
+      if (fs.existsSync(this.metricsFilePath)) {
+        const data = fs.readFileSync(this.metricsFilePath, 'utf-8');
+        const loaded = JSON.parse(data);
+        this.metrics = { ...this.metrics, ...loaded };
+        console.log('✅ Restored metrics from file');
+      }
+    } catch (error) {
+      console.warn('Failed to load metrics from file:', error);
+    }
+  }
+
+  getMetrics(): StressTestMetrics {
+    return { ...this.metrics };
+  }
+
+  exportMetrics(): string {
+    return JSON.stringify(this.metrics, null, 2);
+  }
+}
+
+// ====================
+// Health Check Server
+// ====================
+
+function startHealthCheckServer(client: NodeStressTestClient, port: number = 8080) {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      const metrics = client.getMetrics();
+      const isHealthy = metrics.totalOperations > 0 &&
+                        (metrics.failedOperations / Math.max(metrics.totalOperations, 1)) < 0.05;
+
+      res.writeHead(isHealthy ? 200 : 503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        status: isHealthy ? 'healthy' : 'degraded',
+        uptime: Date.now() - metrics.startTime,
+        totalOperations: metrics.totalOperations,
+        successRate: ((metrics.successfulOperations / Math.max(metrics.totalOperations, 1)) * 100).toFixed(2) + '%',
+        memory: metrics.lastMemorySnapshot,
+      }));
+    } else if (req.url === '/metrics') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(client.exportMetrics());
+    } else {
+      res.writeHead(404);
+      res.end('Not Found');
+    }
+  });
+
+  server.listen(port, () => {
+    console.log(`🏥 Health check server listening on port ${port}`);
+  });
+
+  return server;
+}
+
+// ====================
+// Main Entry Point
+// ====================
+
+const serverUrl = process.env.SERVER_URL || 'ws://localhost:8080';
+const metricsDir = process.env.METRICS_DIR || './metrics';
+const healthCheckPort = parseInt(process.env.PORT || '8080', 10);
+
+console.log('🚀 SyncKit 48-Day Stress Test (Node.js)');
+console.log(`🔗 Server: ${serverUrl}`);
+console.log(`📁 Metrics: ${metricsDir}`);
+console.log('');
+
+const client = new NodeStressTestClient(serverUrl, metricsDir);
+let healthServer: http.Server | null = null;
+
+// Handle graceful shutdown
+const shutdown = async () => {
+  console.log('\n🛑 Received shutdown signal...');
+  client.stop();
+
+  if (healthServer) {
+    healthServer.close(() => {
+      console.log('✅ Health check server stopped');
+    });
+  }
+
+  setTimeout(() => process.exit(0), 1000);
+};
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+
+// Initialize and start
+client.init()
+  .then(() => {
+    // Start health check server
+    healthServer = startHealthCheckServer(client, healthCheckPort);
+
+    // Start stress test
+    return client.start();
+  })
+  .catch((error) => {
+    console.error('❌ Fatal error:', error);
+    process.exit(1);
+  });
+
+console.log('💡 Press Ctrl+C to stop the stress test');

--- a/stress-test/client-node/tsconfig.json
+++ b/stress-test/client-node/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/stress-test/client/.env.example
+++ b/stress-test/client/.env.example
@@ -1,0 +1,2 @@
+# SyncKit Server URL (WebSocket)
+VITE_SERVER_URL=wss://synckit-stress-test.fly.dev

--- a/stress-test/client/index.html
+++ b/stress-test/client/index.html
@@ -1,0 +1,404 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SyncKit 48-Day Stress Test</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+      background: #0d1117;
+      color: #c9d1d9;
+      padding: 20px;
+      line-height: 1.6;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    header {
+      text-align: center;
+      margin-bottom: 30px;
+      padding: 20px;
+      background: #161b22;
+      border-radius: 8px;
+      border: 1px solid #30363d;
+    }
+
+    h1 {
+      color: #58a6ff;
+      font-size: 28px;
+      margin-bottom: 10px;
+    }
+
+    .subtitle {
+      color: #8b949e;
+      font-size: 14px;
+    }
+
+    .status {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 15px;
+      margin-bottom: 20px;
+    }
+
+    .stat-card {
+      background: #161b22;
+      padding: 20px;
+      border-radius: 8px;
+      border: 1px solid #30363d;
+    }
+
+    .stat-label {
+      color: #8b949e;
+      font-size: 12px;
+      text-transform: uppercase;
+      margin-bottom: 8px;
+    }
+
+    .stat-value {
+      font-size: 24px;
+      font-weight: bold;
+      color: #58a6ff;
+    }
+
+    .stat-value.success {
+      color: #3fb950;
+    }
+
+    .stat-value.error {
+      color: #f85149;
+    }
+
+    .stat-value.warning {
+      color: #d29922;
+    }
+
+    .console {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      padding: 20px;
+      height: 500px;
+      overflow-y: auto;
+      font-size: 13px;
+    }
+
+    .console-line {
+      margin-bottom: 4px;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+
+    .progress-bar {
+      width: 100%;
+      height: 8px;
+      background: #21262d;
+      border-radius: 4px;
+      overflow: hidden;
+      margin: 20px 0;
+    }
+
+    .progress-fill {
+      height: 100%;
+      background: linear-gradient(90deg, #58a6ff, #3fb950);
+      width: 0%;
+      transition: width 0.3s ease;
+    }
+
+    .controls {
+      display: flex;
+      gap: 10px;
+      margin-bottom: 20px;
+    }
+
+    button {
+      padding: 10px 20px;
+      font-size: 14px;
+      font-weight: 600;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: all 0.2s;
+      font-family: inherit;
+    }
+
+    .btn-primary {
+      background: #238636;
+      color: white;
+    }
+
+    .btn-primary:hover {
+      background: #2ea043;
+    }
+
+    .btn-danger {
+      background: #da3633;
+      color: white;
+    }
+
+    .btn-danger:hover {
+      background: #f85149;
+    }
+
+    .btn-secondary {
+      background: #21262d;
+      color: #c9d1d9;
+    }
+
+    .btn-secondary:hover {
+      background: #30363d;
+    }
+
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .chart-container {
+      background: #161b22;
+      padding: 20px;
+      border-radius: 8px;
+      border: 1px solid #30363d;
+      margin-bottom: 20px;
+    }
+
+    .chart-title {
+      color: #8b949e;
+      font-size: 14px;
+      margin-bottom: 10px;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+
+    .running-indicator {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      background: #3fb950;
+      border-radius: 50%;
+      margin-right: 8px;
+      animation: pulse 2s infinite;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>🚀 SyncKit 48-Day Production Stress Test</h1>
+      <p class="subtitle">
+        Testing OPFS storage + WebSocket sync under sustained load<br>
+        Target: 48 days continuous operation (Jan 4 - Feb 21, 2026)
+      </p>
+    </header>
+
+    <div class="controls">
+      <button id="startBtn" class="btn-primary" disabled>Starting...</button>
+      <button id="stopBtn" class="btn-danger" disabled>Stop Test</button>
+      <button id="clearBtn" class="btn-secondary">Clear Console</button>
+      <button id="exportBtn" class="btn-secondary">Export Metrics</button>
+    </div>
+
+    <div class="progress-bar">
+      <div id="progressFill" class="progress-fill"></div>
+    </div>
+
+    <div class="status">
+      <div class="stat-card">
+        <div class="stat-label">Status</div>
+        <div id="statusValue" class="stat-value">Initializing...</div>
+      </div>
+
+      <div class="stat-card">
+        <div class="stat-label">Uptime</div>
+        <div id="uptimeValue" class="stat-value">0h 0m</div>
+      </div>
+
+      <div class="stat-card">
+        <div class="stat-label">Operations</div>
+        <div id="operationsValue" class="stat-value">0</div>
+      </div>
+
+      <div class="stat-card">
+        <div class="stat-label">Success Rate</div>
+        <div id="successRateValue" class="stat-value success">100%</div>
+      </div>
+
+      <div class="stat-card">
+        <div class="stat-label">Failed Operations</div>
+        <div id="failedValue" class="stat-value error">0</div>
+      </div>
+
+      <div class="stat-card">
+        <div class="stat-label">Reconnects</div>
+        <div id="reconnectsValue" class="stat-value warning">0</div>
+      </div>
+
+      <div class="stat-card">
+        <div class="stat-label">Memory Usage</div>
+        <div id="memoryValue" class="stat-value">0 MB</div>
+      </div>
+
+      <div class="stat-card">
+        <div class="stat-label">Progress</div>
+        <div id="progressValue" class="stat-value">0.0%</div>
+      </div>
+    </div>
+
+    <div class="chart-container">
+      <div class="chart-title">📝 Console Output</div>
+      <div id="console" class="console"></div>
+    </div>
+  </div>
+
+  <script type="module" src="/stress-test.ts"></script>
+  <script type="module">
+    // Intercept console.log and display in UI
+    const consoleDiv = document.getElementById('console');
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+    const originalError = console.error;
+
+    function addToConsole(message, type = 'log') {
+      const line = document.createElement('div');
+      line.className = 'console-line';
+      line.textContent = message;
+
+      if (type === 'warn') line.style.color = '#d29922';
+      if (type === 'error') line.style.color = '#f85149';
+
+      consoleDiv.appendChild(line);
+      consoleDiv.scrollTop = consoleDiv.scrollHeight;
+
+      // Keep only last 500 lines
+      while (consoleDiv.children.length > 500) {
+        consoleDiv.removeChild(consoleDiv.firstChild);
+      }
+    }
+
+    console.log = (...args) => {
+      originalLog(...args);
+      addToConsole(args.join(' '), 'log');
+      updateDashboard();
+    };
+
+    console.warn = (...args) => {
+      originalWarn(...args);
+      addToConsole(args.join(' '), 'warn');
+      updateDashboard();
+    };
+
+    console.error = (...args) => {
+      originalError(...args);
+      addToConsole(args.join(' '), 'error');
+      updateDashboard();
+    };
+
+    // Update dashboard from metrics
+    function updateDashboard() {
+      try {
+        const metricsStr = localStorage.getItem('synckit-stress-test-metrics');
+        if (!metricsStr) return;
+
+        const metrics = JSON.parse(metricsStr);
+        const uptime = Date.now() - metrics.startTime;
+        const uptimeHours = uptime / (1000 * 60 * 60);
+        const successRate = metrics.totalOperations > 0
+          ? (metrics.successfulOperations / metrics.totalOperations * 100).toFixed(1)
+          : '100.0';
+
+        // Target: 48 days = 1152 hours
+        const targetHours = 48 * 24;
+        const progress = (uptimeHours / targetHours * 100).toFixed(2);
+
+        document.getElementById('statusValue').innerHTML = '<span class="running-indicator"></span>Running';
+        document.getElementById('uptimeValue').textContent = formatUptime(uptime);
+        document.getElementById('operationsValue').textContent = metrics.totalOperations.toLocaleString();
+        document.getElementById('successRateValue').textContent = successRate + '%';
+        document.getElementById('failedValue').textContent = metrics.failedOperations.toLocaleString();
+        document.getElementById('reconnectsValue').textContent = metrics.reconnects.toLocaleString();
+        document.getElementById('progressValue').textContent = progress + '%';
+        document.getElementById('progressFill').style.width = Math.min(parseFloat(progress), 100) + '%';
+
+        // Memory
+        if (metrics.memoryUsage && metrics.memoryUsage.length > 0) {
+          const latest = metrics.memoryUsage[metrics.memoryUsage.length - 1];
+          const memMB = (latest.heapUsed / 1024 / 1024).toFixed(1);
+          document.getElementById('memoryValue').textContent = memMB + ' MB';
+        }
+
+        // Update success rate color
+        const successEl = document.getElementById('successRateValue');
+        if (parseFloat(successRate) >= 99) {
+          successEl.className = 'stat-value success';
+        } else if (parseFloat(successRate) >= 95) {
+          successEl.className = 'stat-value warning';
+        } else {
+          successEl.className = 'stat-value error';
+        }
+      } catch (error) {
+        console.error('Failed to update dashboard:', error);
+      }
+    }
+
+    function formatUptime(ms) {
+      const days = Math.floor(ms / (24 * 60 * 60 * 1000));
+      const hours = Math.floor((ms % (24 * 60 * 60 * 1000)) / (60 * 60 * 1000));
+      const minutes = Math.floor((ms % (60 * 60 * 1000)) / (60 * 1000));
+
+      if (days > 0) {
+        return `${days}d ${hours}h ${minutes}m`;
+      } else if (hours > 0) {
+        return `${hours}h ${minutes}m`;
+      } else {
+        return `${minutes}m`;
+      }
+    }
+
+    // Update dashboard every second
+    setInterval(updateDashboard, 1000);
+
+    // Button handlers
+    document.getElementById('clearBtn').addEventListener('click', () => {
+      consoleDiv.innerHTML = '';
+      console.log('Console cleared');
+    });
+
+    document.getElementById('exportBtn').addEventListener('click', () => {
+      const metricsStr = localStorage.getItem('synckit-stress-test-metrics');
+      if (!metricsStr) {
+        alert('No metrics to export');
+        return;
+      }
+
+      const blob = new Blob([metricsStr], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `synckit-stress-test-${Date.now()}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      console.log('Metrics exported');
+    });
+
+    // Disable buttons initially
+    setTimeout(() => {
+      document.getElementById('startBtn').disabled = true;
+      document.getElementById('startBtn').textContent = 'Running';
+      document.getElementById('stopBtn').disabled = false;
+    }, 2000);
+  </script>
+</body>
+</html>

--- a/stress-test/client/package.json
+++ b/stress-test/client/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@synckit-stress-test/client",
+  "version": "0.3.0",
+  "description": "48-day production stress test client for SyncKit v0.3.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "node --experimental-vm-modules stress-test.js"
+  },
+  "dependencies": {
+    "@synckit-js/sdk": "file:../../sdk"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/stress-test/client/stress-test.ts
+++ b/stress-test/client/stress-test.ts
@@ -1,0 +1,373 @@
+/**
+ * SyncKit 48-Day Production Stress Test
+ *
+ * Tests OPFS storage + WebSocket sync under sustained load.
+ * Memory leak detection via periodic heap snapshots.
+ *
+ * Target: Run continuously for 48 days (Jan 4 - Feb 21, 2026)
+ */
+
+import { SyncKit, OPFSStorage } from '@synckit-js/sdk';
+
+interface TodoItem {
+  id: string;
+  title: string;
+  completed: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface StressTestMetrics {
+  startTime: number;
+  totalOperations: number;
+  successfulOperations: number;
+  failedOperations: number;
+  reconnects: number;
+  errors: string[];
+  memoryUsage: {
+    timestamp: number;
+    heapUsed: number;
+    heapTotal: number;
+    external: number;
+  }[];
+}
+
+class StressTestClient {
+  private synckit: SyncKit | null = null;
+  private storage: OPFSStorage | null = null;
+  private metrics: StressTestMetrics;
+  private isRunning = false;
+  private intervalId: number | null = null;
+  private metricsIntervalId: number | null = null;
+
+  private readonly SERVER_URL: string;
+  private readonly DOCUMENT_ID = 'stress-test-todos';
+  private readonly OPERATION_INTERVAL_MS = 1000; // 1 operation per second
+  private readonly METRICS_INTERVAL_MS = 60000; // Report metrics every minute
+  private readonly MAX_ERRORS_LOGGED = 100;
+
+  constructor(serverUrl: string) {
+    this.SERVER_URL = serverUrl;
+    this.metrics = {
+      startTime: Date.now(),
+      totalOperations: 0,
+      successfulOperations: 0,
+      failedOperations: 0,
+      reconnects: 0,
+      errors: [],
+      memoryUsage: [],
+    };
+
+    // Restore metrics from localStorage if available
+    this.loadMetricsFromStorage();
+  }
+
+  async init(): Promise<void> {
+    console.log('🚀 Initializing stress test client...');
+
+    try {
+      // Initialize OPFS storage
+      this.storage = new OPFSStorage('synckit-stress-test');
+      await this.storage.init();
+      console.log('✅ OPFS storage initialized');
+
+      // Initialize SyncKit
+      this.synckit = new SyncKit({
+        clientId: 'stress-test-client-' + Math.random().toString(36).substring(2, 9),
+        storage: this.storage,
+        serverUrl: this.SERVER_URL,
+      });
+
+      await this.synckit.init();
+      console.log('✅ SyncKit initialized and connected');
+    } catch (error) {
+      console.error('❌ Initialization failed:', error);
+      throw error;
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this.isRunning) {
+      console.warn('⚠️  Stress test is already running');
+      return;
+    }
+
+    this.isRunning = true;
+    console.log('\n🏁 Starting 48-day stress test...');
+    console.log(`📊 Target: ~4,147,200 operations over 48 days`);
+    console.log(`⏱️  Rate: 1 operation/second (86,400 ops/day)`);
+    console.log('');
+
+    // Start operation loop
+    this.intervalId = window.setInterval(() => {
+      this.performOperation().catch(err => {
+        console.error('Operation failed:', err);
+      });
+    }, this.OPERATION_INTERVAL_MS);
+
+    // Start metrics reporting loop
+    this.metricsIntervalId = window.setInterval(() => {
+      this.reportMetrics();
+      this.saveMetricsToStorage();
+    }, this.METRICS_INTERVAL_MS);
+
+    // Perform first operation immediately
+    await this.performOperation();
+  }
+
+  stop(): void {
+    console.log('🛑 Stopping stress test...');
+    this.isRunning = false;
+
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+
+    if (this.metricsIntervalId !== null) {
+      clearInterval(this.metricsIntervalId);
+      this.metricsIntervalId = null;
+    }
+
+    this.saveMetricsToStorage();
+    console.log('✅ Stress test stopped');
+  }
+
+  private async performOperation(): Promise<void> {
+    if (!this.synckit) {
+      throw new Error('SyncKit not initialized');
+    }
+
+    this.metrics.totalOperations++;
+
+    // Weighted random operation selection
+    const rand = Math.random();
+    let operation: string;
+
+    if (rand < 0.40) operation = 'create';       // 40%
+    else if (rand < 0.70) operation = 'update';  // 30%
+    else if (rand < 0.85) operation = 'delete';  // 15%
+    else operation = 'read';                      // 15%
+
+    try {
+      switch (operation) {
+        case 'create':
+          await this.createTodo();
+          break;
+        case 'update':
+          await this.updateTodo();
+          break;
+        case 'delete':
+          await this.deleteTodo();
+          break;
+        case 'read':
+          await this.readTodos();
+          break;
+      }
+
+      this.metrics.successfulOperations++;
+    } catch (error) {
+      this.metrics.failedOperations++;
+      this.logError(`${operation} failed: ${error}`);
+    }
+  }
+
+  private async createTodo(): Promise<void> {
+    if (!this.synckit) throw new Error('SyncKit not initialized');
+
+    const doc = this.synckit.document<{ todos: TodoItem[] }>(this.DOCUMENT_ID);
+    await doc.init();
+
+    const currentData = doc.get();
+    const todos = currentData.todos || [];
+
+    const newTodo: TodoItem = {
+      id: `todo-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+      title: `Stress test todo #${this.metrics.totalOperations}`,
+      completed: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    await doc.set('todos', [...todos, newTodo]);
+  }
+
+  private async updateTodo(): Promise<void> {
+    if (!this.synckit) throw new Error('SyncKit not initialized');
+
+    const doc = this.synckit.document<{ todos: TodoItem[] }>(this.DOCUMENT_ID);
+    await doc.init();
+
+    const currentData = doc.get();
+    const todos = currentData.todos || [];
+
+    if (todos.length === 0) {
+      // No todos to update, create one instead
+      await this.createTodo();
+      return;
+    }
+
+    // Toggle random todo
+    const randomIndex = Math.floor(Math.random() * todos.length);
+    const updatedTodos = todos.map((todo, idx) => {
+      if (idx === randomIndex) {
+        return {
+          ...todo,
+          completed: !todo.completed,
+          updatedAt: Date.now(),
+        };
+      }
+      return todo;
+    });
+
+    await doc.set('todos', updatedTodos);
+  }
+
+  private async deleteTodo(): Promise<void> {
+    if (!this.synckit) throw new Error('SyncKit not initialized');
+
+    const doc = this.synckit.document<{ todos: TodoItem[] }>(this.DOCUMENT_ID);
+    await doc.init();
+
+    const currentData = doc.get();
+    const todos = currentData.todos || [];
+
+    if (todos.length === 0) {
+      // No todos to delete
+      return;
+    }
+
+    // Delete random todo
+    const randomIndex = Math.floor(Math.random() * todos.length);
+    const updatedTodos = todos.filter((_, idx) => idx !== randomIndex);
+
+    await doc.set('todos', updatedTodos);
+  }
+
+  private async readTodos(): Promise<void> {
+    if (!this.synckit) throw new Error('SyncKit not initialized');
+
+    const doc = this.synckit.document<{ todos: TodoItem[] }>(this.DOCUMENT_ID);
+    await doc.init();
+
+    const currentData = doc.get();
+    const todos = currentData.todos || [];
+
+    // Just read the data (already fetched by doc.get())
+    console.log(`📖 Read ${todos.length} todos`);
+  }
+
+  private reportMetrics(): void {
+    const now = Date.now();
+    const uptime = now - this.metrics.startTime;
+    const days = Math.floor(uptime / (1000 * 60 * 60 * 24));
+    const hours = Math.floor((uptime % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+    const minutes = Math.floor((uptime % (1000 * 60 * 60)) / (1000 * 60));
+
+    const successRate = this.metrics.totalOperations > 0
+      ? ((this.metrics.successfulOperations / this.metrics.totalOperations) * 100).toFixed(2)
+      : '0.00';
+
+    console.log('\n📊 === Stress Test Metrics ===');
+    console.log(`⏱️  Uptime: ${days}d ${hours}h ${minutes}m`);
+    console.log(`📈 Total Operations: ${this.metrics.totalOperations.toLocaleString()}`);
+    console.log(`✅ Successful: ${this.metrics.successfulOperations.toLocaleString()} (${successRate}%)`);
+    console.log(`❌ Failed: ${this.metrics.failedOperations.toLocaleString()}`);
+    console.log(`🔄 Reconnects: ${this.metrics.reconnects}`);
+
+    // Memory snapshot (if available)
+    if (performance && (performance as any).memory) {
+      const memory = (performance as any).memory;
+      const heapUsedMB = (memory.usedJSHeapSize / 1024 / 1024).toFixed(2);
+      const heapTotalMB = (memory.totalJSHeapSize / 1024 / 1024).toFixed(2);
+
+      console.log(`💾 Memory: ${heapUsedMB} MB / ${heapTotalMB} MB`);
+
+      // Store memory snapshot
+      this.metrics.memoryUsage.push({
+        timestamp: now,
+        heapUsed: memory.usedJSHeapSize,
+        heapTotal: memory.totalJSHeapSize,
+        external: memory.jsHeapSizeLimit || 0,
+      });
+
+      // Keep only last 1440 snapshots (24 hours at 1 per minute)
+      if (this.metrics.memoryUsage.length > 1440) {
+        this.metrics.memoryUsage = this.metrics.memoryUsage.slice(-1440);
+      }
+    }
+
+    console.log('========================\n');
+  }
+
+  private logError(message: string): void {
+    this.metrics.errors.push(`[${new Date().toISOString()}] ${message}`);
+
+    // Keep only last 100 errors
+    if (this.metrics.errors.length > this.MAX_ERRORS_LOGGED) {
+      this.metrics.errors = this.metrics.errors.slice(-this.MAX_ERRORS_LOGGED);
+    }
+
+    console.error('❌', message);
+  }
+
+  private saveMetricsToStorage(): void {
+    try {
+      localStorage.setItem('stress-test-metrics', JSON.stringify(this.metrics));
+    } catch (error) {
+      console.warn('Failed to save metrics to localStorage:', error);
+    }
+  }
+
+  private loadMetricsFromStorage(): void {
+    try {
+      const stored = localStorage.getItem('stress-test-metrics');
+      if (stored) {
+        const loaded = JSON.parse(stored);
+        this.metrics = { ...this.metrics, ...loaded };
+        console.log('✅ Restored metrics from localStorage');
+      }
+    } catch (error) {
+      console.warn('Failed to load metrics from localStorage:', error);
+    }
+  }
+
+  getMetrics(): StressTestMetrics {
+    return { ...this.metrics };
+  }
+
+  exportMetrics(): string {
+    return JSON.stringify(this.metrics, null, 2);
+  }
+}
+
+// ====================
+// Main Entry Point
+// ====================
+
+const serverUrl = import.meta.env.VITE_SERVER_URL || 'ws://localhost:8080';
+
+console.log('🚀 SyncKit 48-Day Stress Test');
+console.log(`🔗 Server: ${serverUrl}`);
+console.log('');
+
+const client = new StressTestClient(serverUrl);
+
+// Initialize and start
+client.init()
+  .then(() => client.start())
+  .catch((error) => {
+    console.error('❌ Fatal error:', error);
+    process.exit(1);
+  });
+
+// Handle cleanup on page unload
+window.addEventListener('beforeunload', () => {
+  client.stop();
+});
+
+// Expose client globally for debugging
+(window as any).stressTestClient = client;
+
+console.log('💡 Tip: Access client via window.stressTestClient');
+console.log('💡 Export metrics: window.stressTestClient.exportMetrics()');

--- a/stress-test/client/tsconfig.json
+++ b/stress-test/client/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts", "vite-env.d.ts"]
+}

--- a/stress-test/client/vite-env.d.ts
+++ b/stress-test/client/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SERVER_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/stress-test/client/vite.config.js
+++ b/stress-test/client/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    port: 3000,
+    open: true,
+  },
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+  },
+});

--- a/stress-test/fly.toml
+++ b/stress-test/fly.toml
@@ -1,0 +1,95 @@
+# SyncKit Stress Test Server - Fly.io Configuration
+# 48-day production stress test (Jan 4 - Feb 21, 2026)
+
+app = "synckit-stress-test"
+primary_region = "sjc"  # San Jose, CA
+
+# Build configuration - use server Dockerfile
+[build]
+
+[build.dockerfile]
+  dockerfile = "../server/typescript/Dockerfile"
+  context = "../server/typescript"
+
+# Environment variables
+[env]
+  NODE_ENV = "production"
+  HOST = "0.0.0.0"
+  PORT = "8080"
+
+# HTTP service configuration
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+
+  # Keep server running continuously for 48-day test
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+
+  # Health checks - critical for detecting crashes
+  [[services.http_checks]]
+    interval = "30s"
+    timeout = "10s"
+    grace_period = "10s"
+    method = "GET"
+    path = "/health"
+    protocol = "http"
+    restart_limit = 3  # Allow 3 restarts before giving up
+
+    [services.http_checks.headers]
+      User-Agent = "Fly-Health-Check"
+
+  # HTTP handlers
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+    force_https = true
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  # WebSocket configuration - keep connections alive
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+    [services.ports.http_options]
+      idle_timeout = "120s"  # 2 minutes idle before close
+      h2_backend = true
+
+# Concurrency configuration
+[services.concurrency]
+  type = "connections"
+  hard_limit = 100   # Limited for stress test (1 client expected)
+  soft_limit = 80
+
+# Resource allocation - minimal for cost efficiency
+[vm]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 512  # Should be enough with memory leak fixes
+
+# Scaling configuration - single instance for stress test
+[[vm.scaling]]
+  min_count = 1
+  max_count = 1  # No auto-scaling during test
+
+# No database or Redis needed - client uses OPFS storage
+
+# Secrets (set via fly secrets)
+# fly secrets set JWT_SECRET=$(openssl rand -base64 32)
+
+# Monitoring & Metrics
+[metrics]
+  port = 9091
+  path = "/metrics"
+
+# Process configuration
+[processes]
+  app = "bun run start"
+
+# Deploy command:
+# cd stress-test
+# fly deploy --config fly.toml --app synckit-stress-test


### PR DESCRIPTION
## What this is

I built a stress test infrastructure to validate v0.3.0 stability under sustained load. This tests the memory leak fixes from #56 and OPFS storage performance from #55 in a real production-like scenario.

The main piece is a Node.js client that runs 24/7 on Fly.io, generating constant load (1 operation/second) to see if everything holds up over 48 days. There's also a browser client for local testing, but you'd need to keep your tab open for 48 days which... yeah, not realistic.

## Why 48 days?

We want to prove SyncKit can handle extended production use without memory growth or connection issues. The plan is to run it privately for ~18 days first, then make it public on launch day with weeks of proven stability already shown. Then it keeps running publicly for another 30 days so people can see it's actually stable.

## What's included

**Node.js Client** (`stress-test/client-node/`) - The main event
- Runs on Fly.io 24/7 (no local machine needed)
- Does CRUD operations on a SyncKit document
- 40% creates, 30% updates, 15% deletes, 15% reads
- Tracks metrics to persistent volume (survives restarts)
- Health check endpoints: `/health` and `/metrics`
- Memory snapshots every minute
- Costs ~$5/month to run

**Browser Client** (`stress-test/client/`) - For local testing
- Same operations as Node.js version
- Uses OPFS storage (browser-only API)
- Good for quick validation before deployment
- Not practical for 48-day continuous run

**Fly.io Configs**
- Server deployment config (for SyncKit server)
- Client deployment config (for stress test client)
- Persistent volume for metrics
- Health checks and auto-restart

## Running it

**Option A: Node.js on Fly.io (recommended)**
```bash
# Deploy server
cd server/typescript
fly launch --name synckit-stress-test --region sjc
fly secrets set JWT_SECRET=$(openssl rand -base64 32)
fly deploy

# Deploy stress test client
cd stress-test/client-node
fly apps create synckit-stress-test-client --region sjc
fly volumes create stress_test_metrics --region sjc --size 1
fly secrets set SERVER_URL=wss://synckit-stress-test.fly.dev
fly deploy

# Monitor
fly logs -a synckit-stress-test-client
curl https://synckit-stress-test-client.fly.dev/health
```

**Option B: Browser client locally**
```bash
cd stress-test/client
npm install
cp .env.example .env
# Edit .env with server URL
npm run dev
# Keep tab open for 48 days (good luck)
```

## Success criteria

We're looking for:
- >99% success rate on operations
- <10 unexpected disconnections over 48 days
- Memory usage stays flat (no linear growth)
- No crashes or data corruption

If any of those fail, we've got a problem to fix before v0.3.0 launches.

## What happens next

After this merges I'll deploy it and start the test. Then we build LocalWrite (the showcase app) in parallel. By launch day we'll have weeks of proven stability to point to.

## Files

- `stress-test/client-node/` - Node.js stress test client (Fly.io deployment)
- `stress-test/client/` - Browser client (local testing)
- `stress-test/README.md` - Documentation
- `stress-test/fly.toml` - Server deployment config

Related to #56 (memory leaks), #55 (OPFS), #58 (benchmarks)