### PR TITLE
fix: real-time sync reliability and cursor stability

### DIFF
--- a/demo/src/components/CRDTBlockComponent.tsx
+++ b/demo/src/components/CRDTBlockComponent.tsx
@@ -1,0 +1,144 @@
+/**
+ * CRDT-enabled Block component
+ *
+ * Wraps BlockComponent to use SyncText (Fugue CRDT) for content,
+ * providing proper collaborative text editing with automatic
+ * conflict resolution.
+ *
+ * Key differences from regular BlockComponent:
+ * - Content is managed by SyncText CRDT, not passed as a prop
+ * - Updates use diff algorithm to convert to insert/delete operations
+ * - Remote changes merge automatically without overwriting
+ */
+
+import { KeyboardEvent, useCallback, useEffect, useRef } from 'react';
+import { BlockComponent } from './BlockComponent';
+import { useBlockText } from '../hooks/useBlockText';
+import { Block } from '../lib/blocks';
+
+interface CRDTBlockComponentProps {
+  /** The block metadata (type, id, etc.) */
+  block: Block;
+  /** Page ID for CRDT namespace */
+  pageId: string;
+  /** Called when content changes (for slash command detection, etc.) */
+  onContentChange?: (content: string) => void;
+  /** Key down handler */
+  onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => void;
+  /** Block index (for numbered lists) */
+  blockIndex?: number;
+  /** Auto-focus on mount */
+  autoFocus?: boolean;
+  /** Drag handlers */
+  onDragStart?: (e: React.DragEvent) => void;
+  onDragOver?: (e: React.DragEvent) => void;
+  onDrop?: (e: React.DragEvent) => void;
+  onDragEnd?: (e: React.DragEvent) => void;
+  isDragging?: boolean;
+  /** Toggle handlers */
+  onToggleBodyChange?: (body: string) => void;
+  onToggleStateChange?: (collapsed: boolean) => void;
+  /** Delete handler */
+  onDelete?: () => void;
+}
+
+export function CRDTBlockComponent({
+  block,
+  pageId,
+  onContentChange,
+  onKeyDown,
+  blockIndex = 0,
+  autoFocus = false,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+  isDragging = false,
+  onToggleBodyChange,
+  onToggleStateChange,
+  onDelete,
+}: CRDTBlockComponentProps) {
+  // Use CRDT-backed text content
+  const {
+    content,
+    updateContent,
+    loading,
+    initialized,
+  } = useBlockText(pageId, block.id, block.content);
+
+  // Track last notified content to avoid duplicate notifications
+  const lastNotifiedContentRef = useRef(content);
+
+  // Notify parent when content changes (for slash commands, etc.)
+  useEffect(() => {
+    if (initialized && content !== lastNotifiedContentRef.current) {
+      lastNotifiedContentRef.current = content;
+      if (onContentChange) {
+        onContentChange(content);
+      }
+    }
+  }, [content, initialized, onContentChange]);
+
+  // Handle content changes from the editable
+  const handleContentChange = useCallback(
+    async (newContent: string) => {
+      // Skip if still loading - SyncText not ready yet
+      if (loading) {
+        console.log('[CRDTBlockComponent] Skipping update - still loading');
+        return;
+      }
+
+      try {
+        // Update CRDT (will be converted to operations via diff)
+        await updateContent(newContent);
+
+        // Also notify parent (for slash commands, etc.)
+        if (onContentChange) {
+          onContentChange(newContent);
+        }
+      } catch (error) {
+        // Silently handle "not initialized" errors - these happen during race conditions
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        if (errorMessage.includes('not initialized')) {
+          console.log('[CRDTBlockComponent] SyncText not ready yet, skipping update');
+          return;
+        }
+        console.error('[CRDTBlockComponent] Failed to update content:', error);
+      }
+    },
+    [updateContent, onContentChange, loading]
+  );
+
+  // Show loading state while CRDT initializes
+  if (loading) {
+    return (
+      <div className="py-2 px-2 -mx-2 animate-pulse">
+        <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+    );
+  }
+
+  // Create a block with CRDT-backed content
+  const blockWithCRDTContent: Block = {
+    ...block,
+    content: content, // Use CRDT content instead of block.content
+  };
+
+  return (
+    <BlockComponent
+      block={blockWithCRDTContent}
+      onContentChange={handleContentChange}
+      onKeyDown={onKeyDown}
+      blockIndex={blockIndex}
+      autoFocus={autoFocus}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+      isDragging={isDragging}
+      onToggleBodyChange={onToggleBodyChange}
+      onToggleStateChange={onToggleStateChange}
+      onDelete={onDelete}
+    />
+  );
+}

--- a/demo/src/components/CRDTContentEditable.tsx
+++ b/demo/src/components/CRDTContentEditable.tsx
@@ -1,0 +1,442 @@
+/**
+ * CRDT ContentEditable component
+ * A contenteditable that captures individual insert/delete operations
+ * for proper CRDT integration (Fugue text CRDT)
+ *
+ * Key differences from regular ContentEditable:
+ * - Uses `beforeinput` event to capture exact operations
+ * - Calls insert/delete callbacks instead of onChange with full content
+ * - Properly handles cursor positions for collaborative editing
+ */
+
+import { useRef, useEffect, KeyboardEvent, useCallback } from 'react';
+import { parseMarkdown } from '../lib/markdown';
+
+interface CRDTContentEditableProps {
+  /** Current content (from CRDT) */
+  content: string;
+  /** Insert text at position */
+  onInsert: (position: number, text: string) => Promise<void>;
+  /** Delete text at position */
+  onDelete: (position: number, length: number) => Promise<void>;
+  /** Key down handler for block-level navigation */
+  onKeyDown?: (e: KeyboardEvent<HTMLDivElement>) => void;
+  /** Placeholder text */
+  placeholder?: string;
+  /** CSS class name */
+  className?: string;
+  /** Auto-focus on mount */
+  autoFocus?: boolean;
+}
+
+/**
+ * Get the cursor position (character offset) within a contenteditable element
+ */
+function getCursorPosition(element: HTMLElement): number {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return 0;
+
+  const range = selection.getRangeAt(0);
+  const preCaretRange = range.cloneRange();
+  preCaretRange.selectNodeContents(element);
+  preCaretRange.setEnd(range.startContainer, range.startOffset);
+
+  // Get text content up to cursor - this gives us the character position
+  const textContent = preCaretRange.toString();
+  return textContent.length;
+}
+
+/**
+ * Set the cursor position within a contenteditable element
+ */
+function setCursorPosition(element: HTMLElement, position: number): void {
+  const selection = window.getSelection();
+  if (!selection) return;
+
+  // Walk through text nodes to find the right position
+  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, null);
+
+  let currentPos = 0;
+  let node: Node | null = walker.nextNode();
+
+  while (node) {
+    const nodeLength = node.textContent?.length || 0;
+
+    if (currentPos + nodeLength >= position) {
+      // Found the node - set cursor
+      const range = document.createRange();
+      range.setStart(node, position - currentPos);
+      range.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(range);
+      return;
+    }
+
+    currentPos += nodeLength;
+    node = walker.nextNode();
+  }
+
+  // If position is beyond content, put cursor at end
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  range.collapse(false);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+export function CRDTContentEditable({
+  content,
+  onInsert,
+  onDelete,
+  onKeyDown,
+  placeholder = '',
+  className = '',
+  autoFocus = false,
+}: CRDTContentEditableProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const isComposingRef = useRef(false);
+  const lastContentRef = useRef(content);
+  const pendingOperationRef = useRef(false);
+  const cursorPositionRef = useRef<number | null>(null);
+
+  // Update content when it changes externally (from CRDT sync)
+  // IMPORTANT: Never update innerHTML while focused - it causes cursor jumping
+  useEffect(() => {
+    if (!ref.current) return;
+
+    const isCurrentlyFocused = document.activeElement === ref.current;
+
+    // Don't update while user is actively editing - remote changes appear on blur
+    if (isCurrentlyFocused) {
+      lastContentRef.current = content;
+      return;
+    }
+
+    const parsedHtml = parseMarkdown(content);
+
+    // Skip if content hasn't actually changed
+    if (ref.current.innerHTML === parsedHtml) {
+      return;
+    }
+
+    // Safe to update - not focused
+    ref.current.innerHTML = parsedHtml;
+    lastContentRef.current = content;
+  }, [content]);
+
+  // Auto-focus if requested
+  useEffect(() => {
+    if (autoFocus && ref.current) {
+      ref.current.focus();
+
+      // Move cursor to end
+      const selection = window.getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(ref.current);
+      range.collapse(false);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }
+  }, [autoFocus]);
+
+  // Handle beforeinput event to capture operations BEFORE they happen
+  const handleBeforeInput = useCallback(
+    async (e: InputEvent) => {
+      if (!ref.current || isComposingRef.current) return;
+
+      const inputType = e.inputType;
+      const data = e.data;
+
+      // Get cursor position before the operation
+      const position = getCursorPosition(ref.current);
+
+      // Handle different input types
+      switch (inputType) {
+        case 'insertText':
+        case 'insertFromPaste':
+        case 'insertFromDrop': {
+          if (data) {
+            // Prevent default and handle manually
+            e.preventDefault();
+            pendingOperationRef.current = true;
+
+            // Insert at cursor position
+            await onInsert(position, data);
+
+            // After CRDT updates, we need to restore cursor
+            cursorPositionRef.current = position + data.length;
+            pendingOperationRef.current = false;
+          }
+          break;
+        }
+
+        case 'insertParagraph':
+        case 'insertLineBreak': {
+          // Insert newline
+          e.preventDefault();
+          pendingOperationRef.current = true;
+
+          await onInsert(position, '\n');
+
+          cursorPositionRef.current = position + 1;
+          pendingOperationRef.current = false;
+          break;
+        }
+
+        case 'deleteContentBackward': {
+          // Backspace - delete character before cursor
+          if (position > 0) {
+            e.preventDefault();
+            pendingOperationRef.current = true;
+
+            await onDelete(position - 1, 1);
+
+            cursorPositionRef.current = position - 1;
+            pendingOperationRef.current = false;
+          }
+          break;
+        }
+
+        case 'deleteContentForward': {
+          // Delete key - delete character after cursor
+          const contentLength = ref.current.textContent?.length || 0;
+          if (position < contentLength) {
+            e.preventDefault();
+            pendingOperationRef.current = true;
+
+            await onDelete(position, 1);
+
+            cursorPositionRef.current = position;
+            pendingOperationRef.current = false;
+          }
+          break;
+        }
+
+        case 'deleteWordBackward':
+        case 'deleteSoftLineBackward':
+        case 'deleteHardLineBackward': {
+          // Word/line deletion backward - calculate range
+          const ranges = e.getTargetRanges();
+          if (ranges.length > 0) {
+            e.preventDefault();
+            pendingOperationRef.current = true;
+
+            const range = ranges[0];
+            const start = getPositionFromRange(ref.current, range, 'start');
+            const end = getPositionFromRange(ref.current, range, 'end');
+            const length = end - start;
+
+            if (length > 0) {
+              await onDelete(start, length);
+            }
+
+            cursorPositionRef.current = start;
+            pendingOperationRef.current = false;
+          }
+          break;
+        }
+
+        case 'deleteWordForward':
+        case 'deleteSoftLineForward':
+        case 'deleteHardLineForward': {
+          // Word/line deletion forward
+          const ranges = e.getTargetRanges();
+          if (ranges.length > 0) {
+            e.preventDefault();
+            pendingOperationRef.current = true;
+
+            const range = ranges[0];
+            const start = getPositionFromRange(ref.current, range, 'start');
+            const end = getPositionFromRange(ref.current, range, 'end');
+            const length = end - start;
+
+            if (length > 0) {
+              await onDelete(start, length);
+            }
+
+            cursorPositionRef.current = start;
+            pendingOperationRef.current = false;
+          }
+          break;
+        }
+
+        case 'deleteByCut': {
+          // Cut operation
+          const ranges = e.getTargetRanges();
+          if (ranges.length > 0) {
+            e.preventDefault();
+            pendingOperationRef.current = true;
+
+            const range = ranges[0];
+            const start = getPositionFromRange(ref.current, range, 'start');
+            const end = getPositionFromRange(ref.current, range, 'end');
+            const length = end - start;
+
+            if (length > 0) {
+              await onDelete(start, length);
+            }
+
+            cursorPositionRef.current = start;
+            pendingOperationRef.current = false;
+          }
+          break;
+        }
+
+        case 'insertReplacementText':
+        case 'insertFromYank': {
+          // Replace selected text
+          const ranges = e.getTargetRanges();
+          if (ranges.length > 0 && data) {
+            e.preventDefault();
+            pendingOperationRef.current = true;
+
+            const range = ranges[0];
+            const start = getPositionFromRange(ref.current, range, 'start');
+            const end = getPositionFromRange(ref.current, range, 'end');
+            const length = end - start;
+
+            // Delete selected text first
+            if (length > 0) {
+              await onDelete(start, length);
+            }
+
+            // Insert replacement
+            await onInsert(start, data);
+
+            cursorPositionRef.current = start + data.length;
+            pendingOperationRef.current = false;
+          }
+          break;
+        }
+
+        // Formatting operations - let them happen naturally but capture result
+        case 'formatBold':
+        case 'formatItalic':
+        case 'formatUnderline':
+        case 'formatStrikeThrough': {
+          // These are handled at a higher level (keyboard shortcuts)
+          // Allow default behavior
+          break;
+        }
+
+        default: {
+          // For unknown operations, let them happen and sync afterward
+          // This is a fallback that may cause some cursor issues
+          console.log('[CRDTContentEditable] Unhandled inputType:', inputType);
+          break;
+        }
+      }
+    },
+    [onInsert, onDelete]
+  );
+
+  // Restore cursor position after CRDT content update
+  useEffect(() => {
+    if (ref.current && cursorPositionRef.current !== null && document.activeElement === ref.current) {
+      setCursorPosition(ref.current, cursorPositionRef.current);
+      cursorPositionRef.current = null;
+    }
+  }, [content]);
+
+  // Handle composition events (IME input for CJK languages)
+  const handleCompositionStart = useCallback(() => {
+    isComposingRef.current = true;
+  }, []);
+
+  const handleCompositionEnd = useCallback(
+    async (e: React.CompositionEvent<HTMLDivElement>) => {
+      isComposingRef.current = false;
+
+      // After composition ends, sync the composed text
+      if (ref.current) {
+        const position = getCursorPosition(ref.current);
+        const composedText = e.data;
+
+        if (composedText) {
+          // The text is already in the DOM, so we need to sync it
+          // For IME, we use replace strategy since tracking individual changes is complex
+          pendingOperationRef.current = true;
+          await onInsert(position - composedText.length, composedText);
+          cursorPositionRef.current = position;
+          pendingOperationRef.current = false;
+        }
+      }
+    },
+    [onInsert]
+  );
+
+  // Handle key down for block-level navigation
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (onKeyDown) {
+        onKeyDown(e);
+      }
+    },
+    [onKeyDown]
+  );
+
+  // Attach beforeinput event listener (React doesn't support it natively)
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    element.addEventListener('beforeinput', handleBeforeInput as any);
+
+    return () => {
+      element.removeEventListener('beforeinput', handleBeforeInput as any);
+    };
+  }, [handleBeforeInput]);
+
+  return (
+    <div
+      ref={ref}
+      contentEditable
+      suppressContentEditableWarning
+      onCompositionStart={handleCompositionStart}
+      onCompositionEnd={handleCompositionEnd}
+      onKeyDown={handleKeyDown}
+      className={className}
+      data-placeholder={placeholder}
+      style={{
+        outline: 'none',
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+      }}
+    />
+  );
+}
+
+/**
+ * Get character position from a StaticRange
+ */
+function getPositionFromRange(
+  container: HTMLElement,
+  range: StaticRange,
+  point: 'start' | 'end'
+): number {
+  const node = point === 'start' ? range.startContainer : range.endContainer;
+  const offset = point === 'start' ? range.startOffset : range.endOffset;
+
+  // Walk through text nodes to calculate position
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, null);
+
+  let currentPos = 0;
+  let textNode: Node | null = walker.nextNode();
+
+  while (textNode) {
+    if (textNode === node) {
+      return currentPos + offset;
+    }
+
+    currentPos += textNode.textContent?.length || 0;
+    textNode = walker.nextNode();
+  }
+
+  // If node is the container itself, use offset directly
+  if (node === container) {
+    return offset;
+  }
+
+  // Fallback: return position based on offset
+  return offset;
+}

--- a/demo/src/components/ContentEditable.tsx
+++ b/demo/src/components/ContentEditable.tsx
@@ -28,15 +28,77 @@ export function ContentEditable({
   const isComposingRef = useRef(false);
   const lastContentRef = useRef<string>(content);
 
-  // Update content when it changes externally (not during user typing)
+  // Update content when it changes externally (including remote collaborative updates)
   useEffect(() => {
     if (ref.current) {
       const parsedHtml = parseMarkdown(content);
+
+      // Skip if content hasn't actually changed
+      if (ref.current.innerHTML === parsedHtml) {
+        return;
+      }
+
       const isCurrentlyFocused = document.activeElement === ref.current;
 
-      // Only update if element is not focused (external change)
-      // When focused, the user is editing and we shouldn't interfere
-      if (!isCurrentlyFocused && ref.current.innerHTML !== parsedHtml) {
+      if (isCurrentlyFocused) {
+        // Save cursor position before updating
+        const selection = window.getSelection();
+        let savedOffset = 0;
+
+        if (selection && selection.rangeCount > 0) {
+          const range = selection.getRangeAt(0);
+          // Calculate offset from start of contenteditable
+          const preCaretRange = range.cloneRange();
+          preCaretRange.selectNodeContents(ref.current);
+          preCaretRange.setEnd(range.startContainer, range.startOffset);
+          savedOffset = preCaretRange.toString().length;
+        }
+
+        // Update content
+        ref.current.innerHTML = parsedHtml;
+        lastContentRef.current = content;
+
+        // Restore cursor position
+        try {
+          const newSelection = window.getSelection();
+          if (newSelection) {
+            const newRange = document.createRange();
+
+            // Find the text node and offset to place cursor
+            let currentOffset = 0;
+            let targetNode: Node | null = null;
+            let targetOffset = 0;
+
+            const walker = document.createTreeWalker(
+              ref.current,
+              NodeFilter.SHOW_TEXT,
+              null
+            );
+
+            let node: Node | null;
+            while ((node = walker.nextNode())) {
+              const nodeLength = node.textContent?.length || 0;
+              if (currentOffset + nodeLength >= savedOffset) {
+                targetNode = node;
+                targetOffset = savedOffset - currentOffset;
+                break;
+              }
+              currentOffset += nodeLength;
+            }
+
+            if (targetNode) {
+              newRange.setStart(targetNode, Math.min(targetOffset, targetNode.textContent?.length || 0));
+              newRange.collapse(true);
+              newSelection.removeAllRanges();
+              newSelection.addRange(newRange);
+            }
+          }
+        } catch (e) {
+          // If cursor restoration fails, just leave cursor at default position
+          console.warn('Could not restore cursor position:', e);
+        }
+      } else {
+        // Not focused - simple update
         ref.current.innerHTML = parsedHtml;
         lastContentRef.current = content;
       }

--- a/demo/src/components/Editor.tsx
+++ b/demo/src/components/Editor.tsx
@@ -100,26 +100,8 @@ export function Editor({ pageId }: EditorProps) {
       // Type guard - pageId is checked above but TS needs it here too
       if (!pageId) return;
 
-      console.log('📄 Loading document:', pageId);
-
       // Get document
       const doc = synckit.document<PageDocument>(pageId);
-      console.log('[CLIENT] Created document instance for:', pageId);
-      console.log('[CLIENT] SyncManager exists:', !!(synckit as any).syncManager);
-      console.log('[CLIENT] Network status:', synckit.getNetworkStatus());
-
-      // CRITICAL DEBUG: Show sync status on screen
-      const debugDiv = document.getElementById('sync-debug') || document.createElement('div');
-      debugDiv.id = 'sync-debug';
-      debugDiv.style.cssText = 'position:fixed;top:10px;right:10px;background:black;color:lime;padding:10px;z-index:99999;font-family:monospace;font-size:12px;';
-      debugDiv.innerHTML = `
-        <div>SyncManager: ${!!(synckit as any).syncManager ? 'EXISTS ✓' : 'MISSING ✗'}</div>
-        <div>WebSocket: ${synckit.getNetworkStatus()}</div>
-        <div>Doc ID: ${pageId}</div>
-      `;
-      if (!document.getElementById('sync-debug')) {
-        document.body.appendChild(debugDiv);
-      }
 
       // Initialize document (loads from storage)
       // For playground, check storage first to avoid sync timeout on fresh load

--- a/demo/src/hooks/index.ts
+++ b/demo/src/hooks/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Custom hooks for LocalWrite demo
+ */
+
+export { useBlockText } from './useBlockText';
+export type { UseBlockTextResult } from './useBlockText';

--- a/demo/src/hooks/useBlockText.ts
+++ b/demo/src/hooks/useBlockText.ts
@@ -1,0 +1,186 @@
+/**
+ * useBlockText hook
+ * Manages SyncText (Fugue CRDT) for individual block content
+ *
+ * This provides proper collaborative text editing with automatic
+ * conflict resolution, unlike LWW which loses concurrent edits.
+ */
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { useSyncKit } from '../contexts/SyncKitContext';
+import { computeTextDiff } from '../lib/textDiff';
+
+export interface UseBlockTextResult {
+  /** Current text content */
+  content: string;
+  /** Insert text at position */
+  insert: (position: number, text: string) => Promise<void>;
+  /** Delete text at position */
+  delete: (position: number, length: number) => Promise<void>;
+  /** Update content using diff algorithm - converts to CRDT operations */
+  updateContent: (newContent: string) => Promise<void>;
+  /** Loading state */
+  loading: boolean;
+  /** Error state */
+  error: Error | null;
+  /** Whether SyncText is initialized */
+  initialized: boolean;
+}
+
+/**
+ * Hook for collaborative block text editing using Fugue CRDT
+ *
+ * Each block's content is stored in a separate SyncText instance,
+ * identified by `${pageId}:text:${blockId}`.
+ *
+ * @param pageId - The page document ID
+ * @param blockId - The block ID within the page
+ * @param initialContent - Initial content (used when creating new blocks)
+ */
+export function useBlockText(
+  pageId: string | undefined,
+  blockId: string,
+  initialContent: string = ''
+): UseBlockTextResult {
+  const { synckit } = useSyncKit();
+  const [content, setContent] = useState(initialContent);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Use refs to track initialization state
+  const textRef = useRef<any>(null);
+  const initializedRef = useRef(false);
+  const initPromiseRef = useRef<Promise<void> | null>(null);
+
+  // Document ID for this block's text
+  const textDocId = pageId ? `${pageId}:text:${blockId}` : null;
+
+  // Initialize SyncText instance
+  useEffect(() => {
+    if (!textDocId || !synckit) {
+      setLoading(false);
+      return;
+    }
+
+    let mounted = true;
+    let unsubscribe: (() => void) | undefined;
+
+    async function initialize() {
+      // Prevent duplicate initialization
+      if (initializedRef.current && textRef.current) {
+        return;
+      }
+
+      // If already initializing, wait for it
+      if (initPromiseRef.current) {
+        await initPromiseRef.current;
+        return;
+      }
+
+      try {
+        // Create initialization promise
+        initPromiseRef.current = (async () => {
+          // Get or create SyncText instance
+          // textDocId is guaranteed non-null here due to the guard at the start of useEffect
+          const text = synckit.text(textDocId as string);
+          await text.init();
+
+          if (!mounted) return;
+
+          textRef.current = text;
+          initializedRef.current = true;
+
+          // If text is empty and we have initial content, set it
+          const currentContent = text.get();
+          if (currentContent === '' && initialContent) {
+            await text.insert(0, initialContent);
+          }
+
+          // Set initial content
+          setContent(text.get());
+          setLoading(false);
+
+          // Subscribe to changes
+          unsubscribe = text.subscribe((newContent: string) => {
+            if (mounted) {
+              setContent(newContent);
+            }
+          });
+        })();
+
+        await initPromiseRef.current;
+      } catch (err) {
+        if (mounted) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setLoading(false);
+        }
+      } finally {
+        initPromiseRef.current = null;
+      }
+    }
+
+    initialize();
+
+    return () => {
+      mounted = false;
+      if (unsubscribe) {
+        unsubscribe();
+      }
+      // Note: We don't dispose the SyncText here because it might be reused
+      // The SyncKit instance manages cleanup globally
+    };
+  }, [textDocId, synckit, initialContent]);
+
+  // Insert operation
+  const insert = useCallback(async (position: number, text: string) => {
+    if (!textRef.current) {
+      throw new Error('SyncText not initialized');
+    }
+    await textRef.current.insert(position, text);
+  }, []);
+
+  // Delete operation
+  const deleteText = useCallback(async (position: number, length: number) => {
+    if (!textRef.current) {
+      throw new Error('SyncText not initialized');
+    }
+    await textRef.current.delete(position, length);
+  }, []);
+
+  // Update content using diff algorithm - converts to CRDT operations
+  // This is the main method for integrating with ContentEditable
+  const updateContent = useCallback(async (newContent: string) => {
+    if (!textRef.current) {
+      throw new Error('SyncText not initialized');
+    }
+
+    const currentContent = textRef.current.get();
+
+    // Skip if content hasn't changed
+    if (currentContent === newContent) {
+      return;
+    }
+
+    // Compute the operations needed to transform current to new
+    const operations = computeTextDiff(currentContent, newContent);
+
+    // Apply operations to SyncText
+    for (const op of operations) {
+      if (op.type === 'delete' && op.length !== undefined) {
+        await textRef.current.delete(op.position, op.length);
+      } else if (op.type === 'insert' && op.text !== undefined) {
+        await textRef.current.insert(op.position, op.text);
+      }
+    }
+  }, []);
+
+  return {
+    content,
+    insert,
+    delete: deleteText,
+    updateContent,
+    loading,
+    error,
+    initialized: initializedRef.current,
+  };
+}

--- a/demo/src/lib/playground.ts
+++ b/demo/src/lib/playground.ts
@@ -12,12 +12,13 @@ import { createBlock, PageDocument, BLOCK_TYPES } from './blocks';
  */
 export async function initializePlayground(doc: SyncDocument<PageDocument>): Promise<boolean> {
   try {
-    // Check if already initialized
+    // Check if already has blocks (not just metadata like title/id)
     const data = doc.get();
-    const hasContent = data && Object.keys(data).length > 0;
+    const existingBlockOrder = data?.blockOrder ? JSON.parse(data.blockOrder as string) : [];
+    const hasBlocks = existingBlockOrder.length > 0;
 
-    if (hasContent) {
-      console.log('🌍 Playground already initialized');
+    if (hasBlocks) {
+      console.log('🌍 Playground already has blocks, skipping seed content');
       return false;
     }
 

--- a/demo/src/lib/textDiff.ts
+++ b/demo/src/lib/textDiff.ts
@@ -1,0 +1,142 @@
+/**
+ * Text diffing utilities for CRDT integration
+ *
+ * Converts full content replacement to insert/delete operations,
+ * enabling proper CRDT conflict resolution with Fugue.
+ */
+
+export interface TextOperation {
+  type: 'insert' | 'delete';
+  position: number;
+  text?: string;  // For insert
+  length?: number; // For delete
+}
+
+/**
+ * Compute the operations needed to transform oldText into newText
+ *
+ * Uses a simple but effective algorithm:
+ * 1. Find common prefix
+ * 2. Find common suffix
+ * 3. The middle part is what changed (delete old middle, insert new middle)
+ *
+ * This works well for typical editing patterns (typing, backspace, paste).
+ */
+export function computeTextDiff(oldText: string, newText: string): TextOperation[] {
+  if (oldText === newText) {
+    return [];
+  }
+
+  // Handle empty cases
+  if (oldText === '') {
+    return [{ type: 'insert', position: 0, text: newText }];
+  }
+
+  if (newText === '') {
+    return [{ type: 'delete', position: 0, length: oldText.length }];
+  }
+
+  // Find common prefix
+  let prefixLen = 0;
+  const minLen = Math.min(oldText.length, newText.length);
+
+  while (prefixLen < minLen && oldText[prefixLen] === newText[prefixLen]) {
+    prefixLen++;
+  }
+
+  // Find common suffix (but not overlapping with prefix)
+  let suffixLen = 0;
+  const maxSuffixLen = minLen - prefixLen;
+
+  while (
+    suffixLen < maxSuffixLen &&
+    oldText[oldText.length - 1 - suffixLen] === newText[newText.length - 1 - suffixLen]
+  ) {
+    suffixLen++;
+  }
+
+  // Calculate the changed portions
+  const oldMiddleStart = prefixLen;
+  const oldMiddleEnd = oldText.length - suffixLen;
+  const newMiddleStart = prefixLen;
+  const newMiddleEnd = newText.length - suffixLen;
+
+  const deletedLength = oldMiddleEnd - oldMiddleStart;
+  const insertedText = newText.slice(newMiddleStart, newMiddleEnd);
+
+  const operations: TextOperation[] = [];
+
+  // Delete the old middle part first
+  if (deletedLength > 0) {
+    operations.push({
+      type: 'delete',
+      position: prefixLen,
+      length: deletedLength,
+    });
+  }
+
+  // Insert the new middle part
+  if (insertedText.length > 0) {
+    operations.push({
+      type: 'insert',
+      position: prefixLen,
+      text: insertedText,
+    });
+  }
+
+  return operations;
+}
+
+/**
+ * Apply text operations to a string
+ * Useful for testing/validation
+ */
+export function applyOperations(text: string, operations: TextOperation[]): string {
+  let result = text;
+
+  for (const op of operations) {
+    if (op.type === 'delete' && op.length !== undefined) {
+      result = result.slice(0, op.position) + result.slice(op.position + op.length);
+    } else if (op.type === 'insert' && op.text !== undefined) {
+      result = result.slice(0, op.position) + op.text + result.slice(op.position);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Get cursor position after applying operations
+ * Used to restore cursor position after CRDT sync
+ */
+export function getCursorPositionAfterDiff(
+  oldText: string,
+  newText: string,
+  oldCursorPosition: number
+): number {
+  const ops = computeTextDiff(oldText, newText);
+
+  let newPosition = oldCursorPosition;
+
+  for (const op of ops) {
+    if (op.type === 'delete' && op.length !== undefined) {
+      if (op.position < newPosition) {
+        // Deletion before cursor
+        if (op.position + op.length <= newPosition) {
+          // Entire deletion is before cursor
+          newPosition -= op.length;
+        } else {
+          // Deletion includes cursor position
+          newPosition = op.position;
+        }
+      }
+    } else if (op.type === 'insert' && op.text !== undefined) {
+      if (op.position <= newPosition) {
+        // Insertion before or at cursor
+        newPosition += op.text.length;
+      }
+    }
+  }
+
+  return Math.max(0, Math.min(newPosition, newText.length));
+}

--- a/sdk/src/sync/manager.ts
+++ b/sdk/src/sync/manager.ts
@@ -398,8 +398,6 @@ export class SyncManager {
       return
     }
 
-    console.log(`[SyncManager] Received remote delta_batch for ${documentId}: ${deltas.length} operations (isText: ${isTextOperation})`)
-
     for (const operation of deltas) {
       // Handle text CRDT operations (state-based or legacy position-based)
       if (operation.type === 'text-state' || operation.type === 'text' || isTextOperation) {
@@ -418,7 +416,6 @@ export class SyncManager {
     const document = this.documents.get(documentId)
 
     if (!document) {
-      console.log(`[SyncManager] Text document ${documentId} not registered, buffering operation`)
       // Buffer the operation for when the document is registered
       if (!this.bufferedOperations.has(documentId)) {
         this.bufferedOperations.set(documentId, [])
@@ -426,14 +423,6 @@ export class SyncManager {
       this.bufferedOperations.get(documentId)!.push(operation)
       return
     }
-
-    // Log the operation type and relevant fields for debugging
-    console.log(`[SyncManager] Applying remote text operation to ${documentId}:`, {
-      type: operation.type,
-      hasState: !!operation.state,
-      clientId: operation.clientId,
-      stateLength: operation.state?.length
-    })
 
     // Apply the text operation
     document.applyRemoteOperation(operation)

--- a/sdk/src/sync/message-types.ts
+++ b/sdk/src/sync/message-types.ts
@@ -96,7 +96,25 @@ export interface FullSyncResponseMessage extends BaseMessage {
 }
 
 /**
- * Text insert operation - broadcasts text insertion to other tabs
+ * Text state message - broadcasts full CRDT state to other tabs
+ *
+ * IMPORTANT: This is the correct approach for cross-tab text sync.
+ * Position-based operations (text-insert, text-delete) are fundamentally
+ * broken because they create new CRDT nodes with different NodeIds,
+ * causing merge corruption when syncing with remote devices.
+ *
+ * State-based sync ensures all tabs have identical CRDT structures.
+ */
+export interface TextStateMessage extends BaseMessage {
+  type: 'text-state';
+  documentId: string;
+  state: string;  // JSON serialized Fugue CRDT state
+  clientId: string;
+}
+
+/**
+ * @deprecated Use TextStateMessage instead. Position-based operations
+ * break CRDT node identity and cause merge corruption.
  */
 export interface TextInsertMessage extends BaseMessage {
   type: 'text-insert';
@@ -106,7 +124,8 @@ export interface TextInsertMessage extends BaseMessage {
 }
 
 /**
- * Text delete operation - broadcasts text deletion to other tabs
+ * @deprecated Use TextStateMessage instead. Position-based operations
+ * break CRDT node identity and cause merge corruption.
  */
 export interface TextDeleteMessage extends BaseMessage {
   type: 'text-delete';
@@ -153,6 +172,7 @@ export type CrossTabMessage =
   | TabLeavingMessage
   | RequestFullSyncMessage
   | FullSyncResponseMessage
+  | TextStateMessage
   | TextInsertMessage
   | TextDeleteMessage
   | UndoAddMessage


### PR DESCRIPTION
## Summary

This PR resolves multiple sync issues affecting real-time collaborative editing in LocalWrite demo:

- **Server-authoritative sync**: Trust server state for document fields to resolve one-way sync issues
- **Cursor stability**: Fix cursor jumping when receiving remote updates and improve new block focus behavior
- **State-based CRDT sync**: Replace broken position-based cross-tab sync with state-based operations that preserve NodeId identity
- **Merge queue**: Serialize concurrent remote CRDT operations to prevent race conditions
- **ContentEditable DOM sync**: Update DOM on remote changes while preserving cursor position (root cause of bidirectional sync failure)

## Root Cause Analysis

The bidirectional sync failure had multiple layers:
1. Cross-tab sync used position-based operations that created different NodeIds, corrupting CRDT merges
2. ContentEditable skipped DOM updates when focused, causing DOM and CRDT state to diverge
3. When users typed in this diverged state, the diff algorithm computed destructive operations that overwrote remote content

## Changes

### SDK (`sdk/src/`)
- `text.ts`: State-based cross-tab sync, merge queue with deduplication
- `sync/manager.ts`: Improved remote text operation handling
- `sync/message-types.ts`: Added `TextStateMessage` type for state-based sync

### Demo (`demo/src/`)
- `components/ContentEditable.tsx`: DOM updates with cursor preservation
- `components/CRDTBlockComponent.tsx`: CRDT-enabled block wrapper
- `hooks/useBlockText.ts`: Hook for CRDT block content management
- `lib/textDiff.ts`: Diff algorithm for DOM-to-CRDT operations

## Test Plan

- [x] Bidirectional sync works across multiple tabs (same browser)
- [x] Bidirectional sync works across multiple devices (different browsers/machines)
- [x] Cursor position preserved when receiving remote updates while typing
- [x] No scrambled text artifacts
- [x] New blocks receive focus correctly