### PR TITLE
feat(server): add SyncText (Fugue CRDT) persistence

### DIFF
--- a/server/typescript/src/storage/interface.ts
+++ b/server/typescript/src/storage/interface.ts
@@ -51,6 +51,18 @@ export interface SnapshotEntry {
 }
 
 /**
+ * Text document state for SyncText (Fugue CRDT) persistence
+ */
+export interface TextDocumentState {
+  id: string;
+  content: string;      // Plain text content (for display/search)
+  crdtState: string;    // Full Fugue CRDT JSON state
+  clock: bigint;        // Lamport clock
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
  * Storage adapter interface
  */
 export interface StorageAdapter {
@@ -88,6 +100,10 @@ export interface StorageAdapter {
   getLatestSnapshot(documentId: string): Promise<SnapshotEntry | null>;
   listSnapshots(documentId: string, limit?: number): Promise<SnapshotEntry[]>;
   deleteSnapshot(snapshotId: string): Promise<boolean>;
+
+  // Text document operations (for SyncText/Fugue CRDT persistence)
+  saveTextDocument(id: string, content: string, crdtState: string, clock: bigint): Promise<TextDocumentState>;
+  getTextDocument(id: string): Promise<TextDocumentState | null>;
 
   // Maintenance
   cleanup(options?: {


### PR DESCRIPTION
## Summary

Add server-side persistence for SyncText (Fugue CRDT) documents. Previously, text operations were relay-only and lost on server restart. This is a generic server feature for any app using the SDK.

## Problem

- Server received `text-state` operations but only relayed them between clients
- Text state lived only in server memory
- Content disappeared after server restart or when all clients disconnected

## Solution

Store the latest CRDT state per text document in the existing `documents` table.

## Changes

**Storage layer:**
- Add `TextDocumentState` interface
- Add `saveTextDocument()` / `getTextDocument()` methods to StorageAdapter
- Implement in PostgresAdapter using existing documents table with `type='text'` marker

**Coordinator:**
- Add in-memory `textDocuments` cache
- Add `saveTextState()` to persist on receive
- Add `getTextState()` to load from cache or storage

**Server:**
- `handleDeltaBatch()`: Persist `text-state` operations before relaying
- `handleSubscribe()`: Load and send persisted text state to new subscribers

**SDK:**
- `handleSyncResponse()`: Apply `textState` from server if present

## Notes

- Uses existing `documents` table - no database migration needed
- Stores only latest state (not all deltas) - bounded storage
- Backward compatible - falls back to relay-only if storage unavailable