### PR TITLE
feat(server): add /rooms endpoint and per-connection rate limiting

### DIFF
--- a/server/typescript/src/index.ts
+++ b/server/typescript/src/index.ts
@@ -6,6 +6,7 @@ import { config } from './config';
 import { SyncWebSocketServer } from './websocket/server';
 import { auth } from './routes/auth';
 import { createSnapshotRoutes } from './routes/snapshots';
+import { createRoomRoutes } from './routes/rooms';
 import { PostgresAdapter } from './storage/postgres';
 import { RedisPubSub } from './storage/redis';
 import { getCSPHeaders } from './security/middleware';
@@ -155,6 +156,9 @@ const wsServer = new SyncWebSocketServer(
 
 // Mount snapshot routes (requires wsServer for in-memory access)
 app.route('/snapshots', createSnapshotRoutes(storage, wsServer));
+
+// Mount room stats routes (for Stage landing page)
+app.route('/rooms', createRoomRoutes(wsServer));
 
 // console.log(`🚀 SyncKit Server running on ${config.host}:${config.port}`);
 // console.log(`📊 Health check: http://${config.host}:${config.port}/health`);

--- a/server/typescript/src/routes/rooms.ts
+++ b/server/typescript/src/routes/rooms.ts
@@ -1,0 +1,49 @@
+/**
+ * Room Stats Routes
+ *
+ * Provides document statistics filtered for room-based documents.
+ * Used by the demo Stage landing page to display live room info.
+ */
+
+import { Hono } from 'hono';
+import type { SyncWebSocketServer } from '../websocket/server';
+
+export function createRoomRoutes(wsServer: SyncWebSocketServer) {
+  const app = new Hono();
+
+  /**
+   * GET /rooms
+   *
+   * Returns stats for room documents, total connections, and special documents.
+   */
+  app.get('/', (c) => {
+    const stats = wsServer.getStats();
+
+    const rooms = stats.documents.documents
+      .filter((d) => d.id.startsWith('room:') && !d.id.includes(':text:'))
+      .map((d) => ({
+        id: d.id.replace('room:', ''),
+        subscriberCount: d.subscribers,
+        lastModified: d.lastModified,
+      }));
+
+    const wordwall = stats.documents.documents.find(
+      (d) => d.id === 'wordwall'
+    );
+
+    return c.json({
+      rooms,
+      totalConnections: stats.connections.totalConnections,
+      totalRooms: rooms.length,
+      wordwall: wordwall
+        ? {
+            id: wordwall.id,
+            subscriberCount: wordwall.subscribers,
+            lastModified: wordwall.lastModified,
+          }
+        : null,
+    });
+  });
+
+  return app;
+}

--- a/server/typescript/tests/integration/rooms.test.ts
+++ b/server/typescript/tests/integration/rooms.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect } from 'bun:test';
+import { Hono } from 'hono';
+import { createRoomRoutes } from '../../src/routes/rooms';
+
+// Mock wsServer with getStats()
+function createMockWsServer(documents: Array<{ id: string; subscribers: number; lastModified: number }>) {
+  return {
+    getStats() {
+      return {
+        connections: {
+          totalConnections: documents.reduce((sum, d) => sum + d.subscribers, 0),
+          totalUsers: 0,
+          totalClients: 0,
+        },
+        documents: {
+          totalDocuments: documents.length,
+          documents,
+        },
+      };
+    },
+  } as any;
+}
+
+describe('GET /rooms', () => {
+  test('should return empty rooms when no documents exist', async () => {
+    const wsServer = createMockWsServer([]);
+    const app = new Hono();
+    app.route('/rooms', createRoomRoutes(wsServer));
+
+    const res = await app.request('/rooms');
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.rooms).toEqual([]);
+    expect(data.totalConnections).toBe(0);
+    expect(data.totalRooms).toBe(0);
+    expect(data.wordwall).toBeNull();
+  });
+
+  test('should return room documents filtered by room: prefix', async () => {
+    const wsServer = createMockWsServer([
+      { id: 'room:abc123', subscribers: 5, lastModified: 1000 },
+      { id: 'room:def456', subscribers: 12, lastModified: 2000 },
+      { id: 'playground', subscribers: 3, lastModified: 500 },
+    ]);
+    const app = new Hono();
+    app.route('/rooms', createRoomRoutes(wsServer));
+
+    const res = await app.request('/rooms');
+    const data = await res.json();
+
+    expect(data.rooms).toHaveLength(2);
+    expect(data.rooms[0].id).toBe('abc123');
+    expect(data.rooms[0].subscriberCount).toBe(5);
+    expect(data.rooms[1].id).toBe('def456');
+    expect(data.rooms[1].subscriberCount).toBe(12);
+    expect(data.totalRooms).toBe(2);
+    expect(data.totalConnections).toBe(20);
+  });
+
+  test('should exclude room text child documents', async () => {
+    const wsServer = createMockWsServer([
+      { id: 'room:abc123', subscribers: 5, lastModified: 1000 },
+      { id: 'room:abc123:text:block-1', subscribers: 5, lastModified: 1000 },
+      { id: 'room:abc123:text:block-2', subscribers: 5, lastModified: 1000 },
+    ]);
+    const app = new Hono();
+    app.route('/rooms', createRoomRoutes(wsServer));
+
+    const res = await app.request('/rooms');
+    const data = await res.json();
+
+    expect(data.rooms).toHaveLength(1);
+    expect(data.rooms[0].id).toBe('abc123');
+  });
+
+  test('should include wordwall document when present', async () => {
+    const wsServer = createMockWsServer([
+      { id: 'wordwall', subscribers: 8, lastModified: 3000 },
+      { id: 'room:abc123', subscribers: 5, lastModified: 1000 },
+    ]);
+    const app = new Hono();
+    app.route('/rooms', createRoomRoutes(wsServer));
+
+    const res = await app.request('/rooms');
+    const data = await res.json();
+
+    expect(data.wordwall).not.toBeNull();
+    expect(data.wordwall.id).toBe('wordwall');
+    expect(data.wordwall.subscriberCount).toBe(8);
+  });
+});

--- a/server/typescript/tests/unit/security.test.ts
+++ b/server/typescript/tests/unit/security.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  canAccessDocument,
+  ConnectionRateLimiter,
+  SECURITY_LIMITS,
+} from '../../src/security/middleware';
+
+describe('canAccessDocument', () => {
+  test('should allow playground documents', () => {
+    expect(canAccessDocument('playground')).toBe(true);
+    expect(canAccessDocument('playground:text:block-1')).toBe(true);
+  });
+
+  test('should allow room documents', () => {
+    expect(canAccessDocument('room:abc123')).toBe(true);
+    expect(canAccessDocument('room:abc123:text:block-1')).toBe(true);
+  });
+
+  test('should allow wordwall documents', () => {
+    expect(canAccessDocument('wordwall')).toBe(true);
+    expect(canAccessDocument('wordwall:child')).toBe(true);
+  });
+
+  test('should allow page documents (timestamp IDs)', () => {
+    expect(canAccessDocument('1769512101803')).toBe(true);
+    expect(canAccessDocument('1769512101803:text:block-1')).toBe(true);
+  });
+
+  test('should block unknown document patterns', () => {
+    expect(canAccessDocument('secret')).toBe(false);
+    expect(canAccessDocument('admin:config')).toBe(false);
+  });
+});
+
+describe('ConnectionRateLimiter', () => {
+  test('should allow messages within limit', () => {
+    const limiter = new ConnectionRateLimiter();
+
+    for (let i = 0; i < 10; i++) {
+      expect(limiter.canSendMessage('conn-1')).toBe(true);
+      limiter.recordMessage('conn-1');
+    }
+
+    limiter.dispose();
+  });
+
+  test('should track connections independently', () => {
+    const limiter = new ConnectionRateLimiter();
+
+    // Fill up conn-1 near the limit
+    for (let i = 0; i < SECURITY_LIMITS.MAX_MESSAGES_PER_MINUTE - 1; i++) {
+      limiter.recordMessage('conn-1');
+    }
+
+    // conn-2 should still be allowed
+    expect(limiter.canSendMessage('conn-2')).toBe(true);
+
+    limiter.dispose();
+  });
+
+  test('should block messages exceeding limit', () => {
+    const limiter = new ConnectionRateLimiter();
+
+    for (let i = 0; i < SECURITY_LIMITS.MAX_MESSAGES_PER_MINUTE; i++) {
+      limiter.recordMessage('conn-1');
+    }
+
+    expect(limiter.canSendMessage('conn-1')).toBe(false);
+    // Another connection is unaffected
+    expect(limiter.canSendMessage('conn-2')).toBe(true);
+
+    limiter.dispose();
+  });
+
+  test('should clean up removed connections', () => {
+    const limiter = new ConnectionRateLimiter();
+
+    limiter.recordMessage('conn-1');
+    limiter.removeConnection('conn-1');
+
+    // After removal, connection starts fresh
+    expect(limiter.canSendMessage('conn-1')).toBe(true);
+
+    limiter.dispose();
+  });
+});
+
+describe('SECURITY_LIMITS', () => {
+  test('should have word wall limits', () => {
+    expect(SECURITY_LIMITS.WORDWALL_MAX_WORD_LENGTH).toBe(30);
+    expect(SECURITY_LIMITS.WORDWALL_MAX_WORDS).toBe(200);
+    expect(SECURITY_LIMITS.WORDWALL_SUBMISSION_COOLDOWN_MS).toBe(5000);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the server-side infrastructure needed for the upcoming Stage landing page and Word Wall features.

**/rooms endpoint** — New `GET /rooms` route that returns live room stats (subscriber counts, last modified timestamps, total connections). This gives the Stage a lightweight way to poll for room activity without subscribing to every document.

**Per-connection rate limiting** — Replaced the old per-IP rate limiter (which was disabled because it caused retry storms when multiple clients shared an IP) with a new `ConnectionRateLimiter` keyed by connection ID. Each WebSocket connection now gets its own message budget.

**Word wall access** — Added `wordwall` to the allowed document patterns in `canAccessDocument()` and added word wall security limits (max word length, max words, submission cooldown) to `SECURITY_LIMITS`.

## Files changed

- `server/typescript/src/routes/rooms.ts` — New route module for `GET /rooms`
- `server/typescript/src/index.ts` — Mounts the `/rooms` route
- `server/typescript/src/security/middleware.ts` — `ConnectionRateLimiter` class, wordwall document access, limits
- `server/typescript/src/websocket/server.ts` — Switches rate limiting from per-IP to per-connection, cleans up limiter on disconnect
- `server/typescript/tests/integration/rooms.test.ts` — Integration tests for /rooms endpoint
- `server/typescript/tests/unit/security.test.ts` — Unit tests for canAccessDocument, ConnectionRateLimiter, limits

## Test results

14 tests pass across 2 new test files (rooms endpoint shape, document access control, per-connection rate limiting, word wall limits). The 3 pre-existing failures in `protocol.test.ts` are unrelated (serialization format drift).