### PR TITLE
feat(demo): add Stage landing page with routing and room sharding

### DIFF
--- a/demo/src/components/Header.tsx
+++ b/demo/src/components/Header.tsx
@@ -1,137 +1,98 @@
 /**
  * Header component
- * Displays app title, connection status, and storage info
+ * Simplified navigation header for the demo
  */
 
-import { useState, useEffect } from 'react';
 import { useTheme } from '../contexts/ThemeContext';
+import { navigateToStage, type AppRoute } from '../lib/rooms';
 
 interface HeaderProps {
-  storageType?: 'opfs' | 'indexeddb';
   isConnected?: boolean;
-  onSearchClick?: () => void;
-  onExportClick?: () => void;
-  onCreateRoom?: () => void;
+  route: AppRoute;
+  roomId?: string | null;
 }
 
-export function Header({ storageType, isConnected = false, onSearchClick, onExportClick, onCreateRoom }: HeaderProps) {
-  const [currentTime, setCurrentTime] = useState(new Date());
+export function Header({ isConnected = false, route, roomId }: HeaderProps) {
   const { theme, toggleTheme } = useTheme();
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setCurrentTime(new Date());
-    }, 1000);
-    return () => clearInterval(timer);
-  }, []);
 
   return (
     <header className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
-      <div className="flex items-center justify-between px-6 py-4">
-        {/* Left: Logo and Title */}
+      <div className="flex items-center justify-between px-4 sm:px-6 py-3">
+        {/* Left: Back + Logo */}
         <div className="flex items-center gap-3">
-          <div className="w-10 h-10 bg-primary-500 rounded-lg flex items-center justify-center">
-            <span className="text-white text-xl font-bold">L</span>
-          </div>
-          <div>
-            <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+          {route !== 'stage' && (
+            <button
+              onClick={navigateToStage}
+              className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              aria-label="Back to stage"
+            >
+              <svg className="w-5 h-5 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+            </button>
+          )}
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 bg-primary-500 rounded-lg flex items-center justify-center">
+              <span className="text-white text-lg font-bold">L</span>
+            </div>
+            <h1 className="text-lg font-bold text-gray-900 dark:text-gray-100">
               LocalWrite
             </h1>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              SyncKit v0.3.0
-            </p>
           </div>
         </div>
 
-        {/* Center: Search */}
-        {onSearchClick && (
-          <div className="flex-1 flex justify-center px-8">
-            <button
-              onClick={onSearchClick}
-              className="w-full max-w-md px-4 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg flex items-center gap-3 transition-all duration-150 hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-              <span className="text-sm text-gray-500 dark:text-gray-400">Search pages...</span>
-              <div className="ml-auto flex items-center gap-1">
-                <kbd className="px-1.5 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs font-mono text-gray-600 dark:text-gray-300">
-                  {navigator.platform.includes('Mac') ? '⌘' : 'Ctrl'}
-                </kbd>
-                <kbd className="px-1.5 py-0.5 bg-gray-200 dark:bg-gray-600 rounded text-xs font-mono text-gray-600 dark:text-gray-300">P</kbd>
-              </div>
-            </button>
-          </div>
-        )}
-
-        {/* Right: Status indicators */}
-        <div className="flex items-center gap-4">
-          {/* Storage indicator */}
-          {storageType && (
-            <div className="flex items-center gap-2 px-3 py-1.5 bg-gray-100 dark:bg-gray-700 rounded-full">
-              <div className="w-2 h-2 bg-primary-500 rounded-full"></div>
-              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
-                {storageType === 'opfs' ? 'OPFS (Fast)' : 'IndexedDB'}
+        {/* Center: Route indicator */}
+        <div className="hidden sm:flex items-center gap-2">
+          {route === 'room' && roomId && (
+            <div className="flex items-center gap-2 px-3 py-1 bg-primary-50 dark:bg-primary-900/30 rounded-full">
+              <div className="w-2 h-2 bg-primary-500 rounded-full animate-pulse" />
+              <span className="text-xs font-medium text-primary-700 dark:text-primary-300">
+                Room {roomId}
               </span>
             </div>
           )}
+          {route === 'playground' && (
+            <div className="flex items-center gap-2 px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded-full">
+              <span className="text-xs font-medium text-gray-600 dark:text-gray-300">
+                Playground
+              </span>
+            </div>
+          )}
+          {route === 'wordwall' && (
+            <div className="flex items-center gap-2 px-3 py-1 bg-amber-50 dark:bg-amber-900/30 rounded-full">
+              <span className="text-xs font-medium text-amber-700 dark:text-amber-300">
+                Word Wall
+              </span>
+            </div>
+          )}
+        </div>
 
+        {/* Right: Status + Theme */}
+        <div className="flex items-center gap-3">
           {/* Connection indicator */}
-          <div className="flex items-center gap-2 px-3 py-1.5 bg-gray-100 dark:bg-gray-700 rounded-full">
-            <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-gray-400'}`}></div>
-            <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+          <div className="flex items-center gap-1.5 px-2.5 py-1 bg-gray-100 dark:bg-gray-700 rounded-full">
+            <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-gray-400'}`} />
+            <span className="text-xs font-medium text-gray-700 dark:text-gray-300 hidden sm:inline">
               {isConnected ? 'Connected' : 'Offline'}
             </span>
           </div>
 
-          {/* Create Room button */}
-          {onCreateRoom && (
-            <button
-              onClick={onCreateRoom}
-              className="flex items-center gap-2 px-3 py-1.5 bg-primary-500 hover:bg-primary-600 text-white rounded-lg font-medium transition-colors hover:scale-105 active:scale-95"
-              title="Create collaborative room"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
-              </svg>
-              <span className="text-sm">Create Room</span>
-            </button>
-          )}
-
-          {/* Export button */}
-          {onExportClick && (
-            <button
-              onClick={onExportClick}
-              className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 hover:scale-110 active:scale-95 transition-all duration-150"
-              title="Export pages"
-            >
-              <svg className="w-5 h-5 text-gray-700 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-            </button>
-          )}
-
           {/* Theme toggle */}
           <button
             onClick={toggleTheme}
-            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 hover:scale-110 active:scale-95 transition-all duration-150"
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
             aria-label="Toggle theme"
           >
             {theme === 'light' ? (
-              <svg className="w-5 h-5 text-gray-700 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
               </svg>
             ) : (
-              <svg className="w-5 h-5 text-gray-700 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
               </svg>
             )}
           </button>
-
-          {/* Current time */}
-          <div className="text-xs text-gray-500 dark:text-gray-400">
-            {currentTime.toLocaleTimeString()}
-          </div>
         </div>
       </div>
     </header>

--- a/demo/src/components/Layout.tsx
+++ b/demo/src/components/Layout.tsx
@@ -5,22 +5,21 @@
 
 import { ReactNode } from 'react';
 import { Header } from './Header';
+import type { AppRoute } from '../lib/rooms';
 
 interface LayoutProps {
-  storageType?: 'opfs' | 'indexeddb';
   isConnected?: boolean;
+  route: AppRoute;
+  roomId?: string | null;
   sidebar: ReactNode | null;
   children: ReactNode;
-  onSearchClick?: () => void;
-  onExportClick?: () => void;
-  onCreateRoom?: () => void;
 }
 
-export function Layout({ storageType, isConnected, sidebar, children, onSearchClick, onExportClick, onCreateRoom }: LayoutProps) {
+export function Layout({ isConnected, route, roomId, sidebar, children }: LayoutProps) {
   return (
     <div className="h-screen flex flex-col bg-white dark:bg-gray-900">
       {/* Header */}
-      <Header storageType={storageType} isConnected={isConnected} onSearchClick={onSearchClick} onExportClick={onExportClick} onCreateRoom={onCreateRoom} />
+      <Header isConnected={isConnected} route={route} roomId={roomId} />
 
       {/* Main content area */}
       <div className="flex-1 flex overflow-hidden">

--- a/demo/src/components/Stage.tsx
+++ b/demo/src/components/Stage.tsx
@@ -1,0 +1,318 @@
+/**
+ * Stage - Live landing page
+ *
+ * The first thing visitors see. Shows live room stats,
+ * room cards, and action buttons for joining/creating rooms.
+ */
+
+import { useState, useEffect, useRef } from 'react';
+import { ROOM_CAPACITY, pickBestRoom, type RoomInfo } from '../lib/sharding';
+import {
+  generateRoomId,
+  navigateToRoom,
+  navigateToWordWall,
+  navigateToPlayground,
+} from '../lib/rooms';
+import { FEATURES } from '../lib/features';
+
+// Derive the HTTP base URL from the WebSocket server URL
+const SERVER_URL = 'https://synckit-localwrite.fly.dev';
+const POLL_INTERVAL = 3000;
+
+interface RoomStats {
+  rooms: RoomInfo[];
+  totalConnections: number;
+  totalRooms: number;
+  wordwall: { id: string; subscriberCount: number; lastModified: number } | null;
+}
+
+interface StageProps {
+  isConnected: boolean;
+}
+
+export function Stage({ isConnected }: StageProps) {
+  const [stats, setStats] = useState<RoomStats | null>(null);
+  const [fetchError, setFetchError] = useState(false);
+  const prevStatsRef = useRef<RoomStats | null>(null);
+
+  // Poll /rooms endpoint
+  useEffect(() => {
+    let mounted = true;
+
+    const fetchStats = async () => {
+      try {
+        const res = await fetch(`${SERVER_URL}/rooms`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        if (mounted) {
+          prevStatsRef.current = stats;
+          setStats(data);
+          setFetchError(false);
+        }
+      } catch {
+        if (mounted) setFetchError(true);
+      }
+    };
+
+    fetchStats();
+    const interval = setInterval(fetchStats, POLL_INTERVAL);
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  const handleAutoJoin = () => {
+    if (stats) {
+      const bestRoom = pickBestRoom(stats.rooms);
+      if (bestRoom) {
+        navigateToRoom(bestRoom);
+        return;
+      }
+    }
+    // No rooms or all full — create a new one
+    navigateToRoom(generateRoomId());
+  };
+
+  const handleCreateRoom = () => {
+    navigateToRoom(generateRoomId());
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-stone-50 to-stone-100 dark:from-gray-900 dark:to-gray-950">
+      {/* Hero */}
+      <div className="max-w-4xl mx-auto px-4 pt-16 pb-8 text-center">
+        <div className="flex items-center justify-center gap-3 mb-4">
+          <div className="w-12 h-12 bg-primary-500 rounded-xl flex items-center justify-center text-white text-2xl font-bold shadow-lg shadow-primary-500/30">
+            L
+          </div>
+          <h1 className="text-4xl font-bold text-gray-900 dark:text-gray-100">
+            LocalWrite
+          </h1>
+        </div>
+        <p className="text-lg text-gray-600 dark:text-gray-400 mb-2">
+          Real-time collaborative editing powered by CRDTs
+        </p>
+        <p className="text-sm text-gray-500 dark:text-gray-500">
+          Built with <span className="font-medium text-primary-600 dark:text-primary-400">SyncKit</span> — local-first sync that just works
+        </p>
+
+        {/* Connection indicator */}
+        <div className="flex items-center justify-center gap-2 mt-4">
+          <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500 animate-pulse' : 'bg-gray-400'}`} />
+          <span className="text-xs text-gray-500 dark:text-gray-500">
+            {isConnected ? 'Connected to server' : 'Connecting...'}
+          </span>
+        </div>
+      </div>
+
+      {/* Live Stats */}
+      <div className="max-w-4xl mx-auto px-4 pb-8">
+        <div className="flex flex-wrap justify-center gap-6">
+          <StatCard
+            label="People online"
+            value={stats?.totalConnections ?? 0}
+            icon={
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+            }
+          />
+          <StatCard
+            label="Active rooms"
+            value={stats?.totalRooms ?? 0}
+            icon={
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+              </svg>
+            }
+          />
+          {FEATURES.WORD_WALL && stats?.wordwall && (
+            <StatCard
+              label="On word wall"
+              value={stats.wordwall.subscriberCount}
+              icon={
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+                </svg>
+              }
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="max-w-4xl mx-auto px-4 pb-10">
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+          <button
+            onClick={handleAutoJoin}
+            disabled={!isConnected}
+            className="w-full sm:w-auto px-6 py-3 bg-primary-500 hover:bg-primary-600 disabled:bg-gray-400 text-white rounded-xl font-semibold text-lg transition-colors shadow-lg shadow-primary-500/25"
+          >
+            Join a Room
+          </button>
+          <button
+            onClick={handleCreateRoom}
+            disabled={!isConnected}
+            className="w-full sm:w-auto px-6 py-3 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-xl font-semibold transition-colors border border-gray-200 dark:border-gray-700"
+          >
+            Create Private Room
+          </button>
+          {FEATURES.WORD_WALL && (
+            <button
+              onClick={navigateToWordWall}
+              disabled={!isConnected}
+              className="w-full sm:w-auto px-6 py-3 bg-amber-500 hover:bg-amber-600 disabled:bg-gray-400 text-white rounded-xl font-semibold transition-colors shadow-lg shadow-amber-500/25"
+            >
+              Word Wall
+            </button>
+          )}
+          <button
+            onClick={navigateToPlayground}
+            disabled={!isConnected}
+            className="w-full sm:w-auto px-5 py-3 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors text-sm font-medium"
+          >
+            Open Playground
+          </button>
+        </div>
+      </div>
+
+      {/* Room Cards */}
+      {stats && stats.rooms.length > 0 && (
+        <div className="max-w-4xl mx-auto px-4 pb-16">
+          <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4 text-center">
+            Active Rooms
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {stats.rooms.map((room) => (
+              <RoomCard
+                key={room.id}
+                room={room}
+                onJoin={() => navigateToRoom(room.id)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {stats && stats.rooms.length === 0 && (
+        <div className="max-w-4xl mx-auto px-4 pb-16 text-center">
+          <p className="text-gray-500 dark:text-gray-400 text-sm">
+            No active rooms yet. Be the first to create one.
+          </p>
+        </div>
+      )}
+
+      {/* Fetch error */}
+      {fetchError && (
+        <div className="max-w-4xl mx-auto px-4 pb-8 text-center">
+          <p className="text-xs text-gray-400 dark:text-gray-500">
+            Could not reach server for live stats
+          </p>
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="max-w-4xl mx-auto px-4 pb-8 text-center">
+        <p className="text-xs text-gray-400 dark:text-gray-600">
+          Powered by SyncKit &mdash; Fugue CRDT + WASM + WebSocket
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+function StatCard({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: number;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl px-6 py-4 shadow-sm border border-gray-100 dark:border-gray-700 min-w-[140px] text-center">
+      <div className="flex items-center justify-center gap-2 text-gray-400 dark:text-gray-500 mb-1">
+        {icon}
+        <span className="text-xs font-medium uppercase tracking-wider">{label}</span>
+      </div>
+      <div className="text-3xl font-bold text-gray-900 dark:text-gray-100 transition-all duration-300">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function RoomCard({
+  room,
+  onJoin,
+}: {
+  room: RoomInfo;
+  onJoin: () => void;
+}) {
+  const isFull = room.subscriberCount >= ROOM_CAPACITY;
+  const capacityPercent = Math.min(
+    (room.subscriberCount / ROOM_CAPACITY) * 100,
+    100
+  );
+  const isActive =
+    Date.now() - room.lastModified < 30000; // Active in last 30s
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 px-2 py-0.5 rounded">
+            {room.id}
+          </span>
+          {isActive && (
+            <span className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+          )}
+        </div>
+        {isFull && (
+          <span className="text-xs font-medium text-red-500 bg-red-50 dark:bg-red-900/30 px-2 py-0.5 rounded-full">
+            Full
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm text-gray-600 dark:text-gray-400">
+          {room.subscriberCount}/{ROOM_CAPACITY} people
+        </span>
+      </div>
+
+      {/* Capacity bar */}
+      <div className="w-full bg-gray-100 dark:bg-gray-700 rounded-full h-1.5 mb-3">
+        <div
+          className={`h-1.5 rounded-full transition-all duration-500 ${
+            isFull
+              ? 'bg-red-500'
+              : capacityPercent > 75
+                ? 'bg-amber-500'
+                : 'bg-primary-500'
+          }`}
+          style={{ width: `${capacityPercent}%` }}
+        />
+      </div>
+
+      <button
+        onClick={onJoin}
+        disabled={isFull}
+        className={`w-full py-2 rounded-lg text-sm font-medium transition-colors ${
+          isFull
+            ? 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed'
+            : 'bg-primary-500 hover:bg-primary-600 text-white'
+        }`}
+      >
+        {isFull ? 'Room Full' : 'Join'}
+      </button>
+    </div>
+  );
+}

--- a/demo/src/lib/features.ts
+++ b/demo/src/lib/features.ts
@@ -29,6 +29,18 @@ export const FEATURES = {
    * URL-based collaborative spaces (one document per room)
    */
   PRIVATE_ROOMS: true,
+
+  /**
+   * V1: Stage landing page
+   * Live activity dashboard with room stats and auto-join
+   */
+  STAGE: true,
+
+  /**
+   * V1: Word Wall
+   * Global shared word cloud with voting
+   */
+  WORD_WALL: true,
 } as const;
 
 // Type helper for TypeScript

--- a/demo/src/lib/rooms.ts
+++ b/demo/src/lib/rooms.ts
@@ -1,13 +1,61 @@
 /**
- * Room management utilities
- * Handles URL-based collaborative rooms
+ * Room management and routing utilities
+ * Handles URL-based collaborative rooms and app-wide navigation
  */
 
+// ============================================================================
+// Route Detection
+// ============================================================================
+
+export type AppRoute = 'stage' | 'room' | 'wordwall' | 'playground';
+
 /**
- * Generate a random room ID
+ * Determine the current route from the URL hash
+ */
+export function getRouteFromUrl(): AppRoute {
+  const hash = window.location.hash;
+  if (!hash || hash === '#' || hash === '#/') return 'stage';
+  if (hash.match(/^#\/room\/[a-z0-9]+$/i)) return 'room';
+  if (hash === '#/wordwall') return 'wordwall';
+  if (hash === '#/playground') return 'playground';
+  return 'stage';
+}
+
+// ============================================================================
+// Navigation
+// ============================================================================
+
+export function navigateToStage(): void {
+  window.location.hash = '/';
+}
+
+export function navigateToRoom(roomId: string): void {
+  window.location.hash = `/room/${roomId}`;
+}
+
+export function navigateToWordWall(): void {
+  window.location.hash = '/wordwall';
+}
+
+export function navigateToPlayground(): void {
+  window.location.hash = '/playground';
+}
+
+/**
+ * Leave room (go back to stage)
+ */
+export function leaveRoom(): void {
+  navigateToStage();
+}
+
+// ============================================================================
+// Room Utilities
+// ============================================================================
+
+/**
+ * Generate a random room ID (6 alphanumeric chars)
  */
 export function generateRoomId(): string {
-  // Generate a short, memorable room ID (6 chars)
   const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
   let id = '';
   for (let i = 0; i < 6; i++) {
@@ -22,22 +70,8 @@ export function generateRoomId(): string {
  */
 export function getRoomIdFromUrl(): string | null {
   const hash = window.location.hash;
-  const match = hash.match(/^#\/room\/([a-z0-9]+)$/);
+  const match = hash.match(/^#\/room\/([a-z0-9]+)$/i);
   return match ? match[1] : null;
-}
-
-/**
- * Navigate to a room
- */
-export function navigateToRoom(roomId: string): void {
-  window.location.hash = `/room/${roomId}`;
-}
-
-/**
- * Leave room (go back to normal mode)
- */
-export function leaveRoom(): void {
-  window.location.hash = '';
 }
 
 /**

--- a/demo/src/lib/sharding.ts
+++ b/demo/src/lib/sharding.ts
@@ -1,0 +1,25 @@
+/**
+ * Room sharding utilities
+ * Auto-assigns users to rooms based on capacity
+ */
+
+export const ROOM_CAPACITY = 20;
+
+export interface RoomInfo {
+  id: string;
+  subscriberCount: number;
+  lastModified: number;
+}
+
+/**
+ * Pick the best room to join.
+ * Strategy: pick the most populated non-full room.
+ * This fills rooms before creating new ones, so users
+ * are more likely to find active collaborators.
+ */
+export function pickBestRoom(rooms: RoomInfo[]): string | null {
+  const available = rooms
+    .filter((r) => r.subscriberCount < ROOM_CAPACITY)
+    .sort((a, b) => b.subscriberCount - a.subscriberCount);
+  return available.length > 0 ? available[0].id : null;
+}


### PR DESCRIPTION
## Summary

This replaces the default playground view with a Stage landing page — the first thing visitors see when they open the demo.

**Stage** — Polls `GET /rooms` every 3 seconds and displays live stats (people online, active rooms), action buttons (Join a Room, Create Private Room, Word Wall, Playground), and room cards with capacity bars. The auto-join button picks the most populated non-full room using a filling strategy.

**Routing overhaul** — Hash-based routing now supports four views: `#/` (stage), `#/room/{id}` (collaborative room), `#/wordwall` (placeholder for PR3), `#/playground` (original shared document). Route detection and navigation functions are centralized in `rooms.ts`.

**Header cleanup** — Removed the OPFS storage badge, "SyncKit v0.3.0" subtitle, live clock, search bar, and export button. Added a back-to-stage button, route indicator (room ID badge / "Playground" / "Word Wall"), and simplified the layout. Connection dot and theme toggle remain.

**Room sharding** — `pickBestRoom()` selects the most populated room under the 20-person capacity cap. If all rooms are full, a new room is generated. Room cards show a capacity progress bar that turns amber at 75% and red when full.

## Files changed

- `demo/src/components/Stage.tsx` — New Stage landing page with stats, room cards, action buttons
- `demo/src/lib/sharding.ts` — New auto-assignment logic (`pickBestRoom`, `ROOM_CAPACITY`)
- `demo/src/lib/rooms.ts` — Added `AppRoute` type, `getRouteFromUrl()`, navigation functions
- `demo/src/lib/features.ts` — Added `STAGE` and `WORD_WALL` feature flags
- `demo/src/App.tsx` — Route-based rendering (stage/room/wordwall/playground)
- `demo/src/components/Header.tsx` — Simplified with back button, route indicator
- `demo/src/components/Layout.tsx` — Updated props (removed storageType, added route/roomId)

## Test results

TypeScript type-check (`tsc --noEmit`) and full Vite build (`npm run build`) both pass with zero errors.