### PR TITLE
feat(demo): add Word Wall with live voting and tag cloud

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -8,6 +8,7 @@ import { ExportDialog } from './components/ExportDialog';
 import { Cursors } from './components/Cursors';
 import { RoomBanner } from './components/RoomBanner';
 import { Stage } from './components/Stage';
+import { WordWall } from './components/WordWall';
 import { SyncKitProvider, useSyncKit } from './contexts/SyncKitContext';
 import {
   getRouteFromUrl,
@@ -289,17 +290,11 @@ function AppContent() {
     return <Stage isConnected={isConnected} />;
   }
 
-  // Word Wall (placeholder until PR3)
+  // Word Wall
   if (route === 'wordwall') {
     return (
       <Layout isConnected={isConnected} route={route} roomId={null} sidebar={null}>
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center">
-            <div className="text-6xl mb-4">🧱</div>
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">Word Wall</h2>
-            <p className="text-gray-500 dark:text-gray-400">Coming soon</p>
-          </div>
-        </div>
+        <WordWall isConnected={isConnected} />
       </Layout>
     );
   }

--- a/demo/src/components/WordCloud.tsx
+++ b/demo/src/components/WordCloud.tsx
@@ -1,0 +1,65 @@
+/**
+ * WordCloud - Tag cloud renderer
+ *
+ * Displays words at varying font sizes based on vote count.
+ * Each word is a clickable button for voting.
+ */
+
+import { getWordFontSize, getWordColor, type WordEntry } from '../lib/wordwall';
+
+interface WordCloudProps {
+  words: WordEntry[];
+  votedWords: Set<string>;
+  onVote: (slug: string) => void;
+}
+
+export function WordCloud({ words, votedWords, onVote }: WordCloudProps) {
+  const maxVotes = words.length > 0 ? Math.max(...words.map((w) => w.votes)) : 1;
+
+  if (words.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-20 text-gray-400 dark:text-gray-500">
+        <p className="text-lg">No words yet. Be the first to add one.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-3 px-4 py-8">
+      {words.map((word) => {
+        const fontSize = getWordFontSize(word.votes, maxVotes);
+        const color = getWordColor(word.slug);
+        const hasVoted = votedWords.has(word.slug);
+
+        return (
+          <button
+            key={word.slug}
+            onClick={() => !hasVoted && onVote(word.slug)}
+            className={`
+              inline-flex items-center gap-1 px-3 py-1.5 rounded-full
+              transition-all duration-300 ease-out
+              min-h-[44px] min-w-[44px]
+              ${hasVoted
+                ? 'opacity-70 cursor-default ring-2 ring-offset-1 ring-gray-300 dark:ring-gray-600'
+                : 'hover:scale-110 hover:shadow-md cursor-pointer active:scale-95'
+              }
+            `}
+            style={{
+              fontSize: `${fontSize}px`,
+              color,
+              backgroundColor: `${color}10`,
+            }}
+            title={`${word.votes} vote${word.votes !== 1 ? 's' : ''}${hasVoted ? ' (voted)' : ' — click to vote'}`}
+          >
+            <span className="font-semibold whitespace-nowrap">{word.text}</span>
+            {hasVoted && (
+              <svg className="w-3 h-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+              </svg>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/demo/src/components/WordWall.tsx
+++ b/demo/src/components/WordWall.tsx
@@ -1,0 +1,298 @@
+/**
+ * Word Wall - Global shared word cloud with live voting
+ *
+ * Uses a single SyncDocument ("wordwall") with field-per-word.
+ * Each word is stored as `word:{slug}` with text, votes, timestamps.
+ * LWW per-field handles concurrent edits.
+ */
+
+import { useState, useEffect, useRef } from 'react';
+import { useSyncKit } from '../contexts/SyncKitContext';
+import { WordCloud } from './WordCloud';
+import {
+  parseWordsFromDocument,
+  textToSlug,
+  sanitizeInput,
+  isOffensive,
+  findWordToEvict,
+  needsEviction,
+  type WordEntry,
+} from '../lib/wordwall';
+// Use a stable anonymous ID for tracking submissions
+function getAnonymousId(): string {
+  const key = 'localwrite:anonymous-id';
+  let id = localStorage.getItem(key);
+  if (!id) {
+    id = Math.random().toString(36).slice(2, 10);
+    localStorage.setItem(key, id);
+  }
+  return id;
+}
+
+const SUBMISSION_COOLDOWN_MS = 5000;
+const VOTED_WORDS_KEY = 'localwrite:wordwall:voted';
+
+interface WordWallProps {
+  isConnected: boolean;
+}
+
+export function WordWall({ isConnected }: WordWallProps) {
+  const { synckit } = useSyncKit();
+  const [words, setWords] = useState<WordEntry[]>([]);
+  const [input, setInput] = useState('');
+  const [cooldownRemaining, setCooldownRemaining] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [votedWords, setVotedWords] = useState<Set<string>>(() => {
+    try {
+      const stored = localStorage.getItem(VOTED_WORDS_KEY);
+      return stored ? new Set(JSON.parse(stored)) : new Set();
+    } catch {
+      return new Set();
+    }
+  });
+  const [initialized, setInitialized] = useState(false);
+
+  const docRef = useRef<any>(null);
+  const lastSubmitTimeRef = useRef(0);
+  const cooldownTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Persist voted words to localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem(VOTED_WORDS_KEY, JSON.stringify([...votedWords]));
+    } catch {
+      // localStorage might be full or unavailable
+    }
+  }, [votedWords]);
+
+  // Initialize wordwall document
+  useEffect(() => {
+    let mounted = true;
+    let unsubscribe: (() => void) | null = null;
+
+    async function init() {
+      try {
+        const doc = synckit.document('wordwall');
+        await doc.init();
+
+        if (!mounted) return;
+        docRef.current = doc;
+
+        // Initial read
+        const data = doc.get();
+        if (data && mounted) {
+          setWords(parseWordsFromDocument(data as Record<string, unknown>));
+        }
+
+        // Subscribe to changes
+        unsubscribe = doc.subscribe((data: any) => {
+          if (!mounted) return;
+          setWords(parseWordsFromDocument(data as Record<string, unknown>));
+        });
+
+        setInitialized(true);
+      } catch (err) {
+        console.error('Failed to initialize word wall:', err);
+        if (mounted) setError('Failed to connect to word wall');
+      }
+    }
+
+    init();
+
+    return () => {
+      mounted = false;
+      if (unsubscribe) unsubscribe();
+    };
+  }, [synckit]);
+
+  // Cooldown timer
+  useEffect(() => {
+    return () => {
+      if (cooldownTimerRef.current) {
+        clearInterval(cooldownTimerRef.current);
+      }
+    };
+  }, []);
+
+  const startCooldown = () => {
+    lastSubmitTimeRef.current = Date.now();
+    setCooldownRemaining(SUBMISSION_COOLDOWN_MS);
+
+    if (cooldownTimerRef.current) {
+      clearInterval(cooldownTimerRef.current);
+    }
+
+    cooldownTimerRef.current = setInterval(() => {
+      const elapsed = Date.now() - lastSubmitTimeRef.current;
+      const remaining = Math.max(0, SUBMISSION_COOLDOWN_MS - elapsed);
+      setCooldownRemaining(remaining);
+
+      if (remaining === 0 && cooldownTimerRef.current) {
+        clearInterval(cooldownTimerRef.current);
+        cooldownTimerRef.current = null;
+      }
+    }, 100);
+  };
+
+  const handleSubmit = async () => {
+    const doc = docRef.current;
+    if (!doc || !input.trim()) return;
+
+    // Cooldown check
+    const now = Date.now();
+    if (now - lastSubmitTimeRef.current < SUBMISSION_COOLDOWN_MS) {
+      setError(`Wait ${Math.ceil(cooldownRemaining / 1000)}s before submitting again`);
+      return;
+    }
+
+    const text = sanitizeInput(input);
+    if (!text) return;
+
+    // Offensive word check
+    if (isOffensive(text)) {
+      setError('That word is not allowed');
+      setInput('');
+      return;
+    }
+
+    const slug = textToSlug(text);
+    if (!slug) {
+      setError('Invalid characters');
+      return;
+    }
+
+    // Check if word already exists — if so, just vote for it
+    const existing = words.find((w) => w.slug === slug);
+    if (existing) {
+      await handleVote(slug);
+      setInput('');
+      setError(null);
+      startCooldown();
+      return;
+    }
+
+    // Evict if at capacity
+    if (needsEviction(words)) {
+      const toEvict = findWordToEvict(words);
+      if (toEvict) {
+        await doc.set(`word:${toEvict.slug}`, { __deleted: true });
+      }
+    }
+
+    await doc.set(`word:${slug}`, {
+      text,
+      votes: 1,
+      submittedAt: now,
+      submittedBy: getAnonymousId(),
+    });
+
+    // Auto-vote for own word
+    setVotedWords((prev) => new Set([...prev, slug]));
+    setInput('');
+    setError(null);
+    startCooldown();
+  };
+
+  const handleVote = async (slug: string) => {
+    const doc = docRef.current;
+    if (!doc || votedWords.has(slug)) return;
+
+    const word = words.find((w) => w.slug === slug);
+    if (!word) return;
+
+    await doc.set(`word:${slug}`, {
+      text: word.text,
+      votes: word.votes + 1,
+      submittedAt: word.submittedAt,
+      submittedBy: word.submittedBy,
+    });
+
+    setVotedWords((prev) => new Set([...prev, slug]));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      {/* Word Wall content */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-3xl mx-auto px-4 py-8">
+          {/* Title */}
+          <div className="text-center mb-6">
+            <h2 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+              Word Wall
+            </h2>
+            <p className="text-gray-500 dark:text-gray-400">
+              Add a word, vote for your favorites — synced live across everyone
+            </p>
+            {words.length > 0 && (
+              <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                {words.length} word{words.length !== 1 ? 's' : ''} on the wall
+              </p>
+            )}
+          </div>
+
+          {/* Word Cloud */}
+          {initialized ? (
+            <div className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-100 dark:border-gray-700 shadow-sm min-h-[300px] flex items-center justify-center">
+              <WordCloud
+                words={words}
+                votedWords={votedWords}
+                onVote={handleVote}
+              />
+            </div>
+          ) : (
+            <div className="flex items-center justify-center py-20">
+              <div className="w-8 h-8 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Input bar (fixed at bottom) */}
+      <div className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-4 py-4">
+        <div className="max-w-3xl mx-auto">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => {
+                setInput(e.target.value.slice(0, 30));
+                setError(null);
+              }}
+              onKeyDown={handleKeyDown}
+              placeholder="Type a word or phrase..."
+              maxLength={30}
+              disabled={!isConnected || !initialized}
+              className="flex-1 px-4 py-3 bg-gray-100 dark:bg-gray-700 rounded-xl text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-50"
+            />
+            <button
+              onClick={handleSubmit}
+              disabled={!isConnected || !initialized || !input.trim() || cooldownRemaining > 0}
+              className="px-6 py-3 bg-primary-500 hover:bg-primary-600 disabled:bg-gray-400 text-white rounded-xl font-medium transition-colors whitespace-nowrap"
+            >
+              {cooldownRemaining > 0
+                ? `${Math.ceil(cooldownRemaining / 1000)}s`
+                : 'Submit'}
+            </button>
+          </div>
+
+          {/* Error / info messages */}
+          <div className="flex items-center justify-between mt-2 min-h-[20px]">
+            {error && (
+              <p className="text-xs text-red-500">{error}</p>
+            )}
+            <p className="text-xs text-gray-400 dark:text-gray-500 ml-auto">
+              {input.length}/30
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/demo/src/lib/wordwall.ts
+++ b/demo/src/lib/wordwall.ts
@@ -1,0 +1,144 @@
+/**
+ * Word Wall utilities
+ * Handles word submission, voting, filtering, and display logic
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface WordEntry {
+  slug: string;
+  text: string;
+  votes: number;
+  submittedAt: number;
+  submittedBy: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const MAX_WORD_LENGTH = 30;
+const MAX_WORDS = 200;
+const MIN_FONT_SIZE = 14;
+const MAX_FONT_SIZE = 48;
+
+// ============================================================================
+// Offensive Word Filter
+// ============================================================================
+
+// Basic blocklist — not exhaustive, but catches the most common abuse
+const BLOCKLIST = new Set([
+  'fuck', 'shit', 'ass', 'bitch', 'dick', 'pussy', 'cock', 'cunt',
+  'nigger', 'nigga', 'faggot', 'fag', 'retard', 'retarded',
+  'whore', 'slut', 'bastard', 'damn', 'piss',
+  'nazi', 'hitler', 'kys', 'kill',
+]);
+
+export function isOffensive(text: string): boolean {
+  const lower = text.toLowerCase().trim();
+  // Check exact match
+  if (BLOCKLIST.has(lower)) return true;
+  // Check if any blocked word appears as a substring
+  for (const word of BLOCKLIST) {
+    if (lower.includes(word)) return true;
+  }
+  return false;
+}
+
+// ============================================================================
+// Slug / Text Processing
+// ============================================================================
+
+export function textToSlug(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .slice(0, 40);
+}
+
+export function sanitizeInput(text: string): string {
+  return text.trim().slice(0, MAX_WORD_LENGTH);
+}
+
+// ============================================================================
+// Document Parsing
+// ============================================================================
+
+export function parseWordsFromDocument(
+  data: Record<string, unknown>
+): WordEntry[] {
+  const words: WordEntry[] = [];
+
+  for (const [key, value] of Object.entries(data)) {
+    if (!key.startsWith('word:')) continue;
+    if (!value || typeof value !== 'object') continue;
+
+    const v = value as any;
+    // Skip deleted entries
+    if (v.__deleted) continue;
+    if (!v.text || typeof v.votes !== 'number') continue;
+
+    words.push({
+      slug: key.replace('word:', ''),
+      text: v.text,
+      votes: v.votes,
+      submittedAt: v.submittedAt || 0,
+      submittedBy: v.submittedBy || '',
+    });
+  }
+
+  return words.sort((a, b) => b.votes - a.votes);
+}
+
+// ============================================================================
+// Eviction
+// ============================================================================
+
+export function findWordToEvict(words: WordEntry[]): WordEntry | null {
+  if (words.length < MAX_WORDS) return null;
+
+  // Evict: lowest votes first, then oldest
+  const sorted = [...words].sort((a, b) => {
+    if (a.votes !== b.votes) return a.votes - b.votes;
+    return a.submittedAt - b.submittedAt;
+  });
+
+  return sorted[0] || null;
+}
+
+export function needsEviction(words: WordEntry[]): boolean {
+  return words.length >= MAX_WORDS;
+}
+
+// ============================================================================
+// Display
+// ============================================================================
+
+export function getWordFontSize(
+  votes: number,
+  maxVotes: number
+): number {
+  if (maxVotes <= 1) return (MIN_FONT_SIZE + MAX_FONT_SIZE) / 2;
+  const ratio = Math.min(votes / maxVotes, 1);
+  return MIN_FONT_SIZE + ratio * (MAX_FONT_SIZE - MIN_FONT_SIZE);
+}
+
+// 18 distinct colors for words (same count as user palette)
+const WORD_COLORS = [
+  '#10b981', '#f59e0b', '#3b82f6', '#ef4444', '#8b5cf6',
+  '#ec4899', '#14b8a6', '#f97316', '#6366f1', '#84cc16',
+  '#06b6d4', '#d946ef', '#0ea5e9', '#22c55e', '#a855f7',
+  '#e11d48', '#2dd4bf', '#facc15',
+];
+
+export function getWordColor(slug: string): string {
+  let hash = 0;
+  for (let i = 0; i < slug.length; i++) {
+    hash = slug.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return WORD_COLORS[Math.abs(hash) % WORD_COLORS.length];
+}


### PR DESCRIPTION
## Summary

Adds the Word Wall — a global shared experience where all visitors can submit words and vote for favorites. Words are rendered as a tag cloud with font sizes scaled by vote count.

**Data model** — Single SyncDocument with ID `wordwall`. Each word stored as field `word:{slug}` with value `{ text, votes, submittedAt, submittedBy }`. LWW per-field handles concurrent votes (two simultaneous votes on the same word may lose one — acceptable for a demo).

**Tag cloud** — Words rendered as flex-wrap buttons. Font size scales between 14px and 48px based on votes relative to the most-voted word. Each word gets a deterministic color from its slug hash. Voted words show a checkmark and reduced opacity.

**Abuse prevention** — 5-second cooldown between submissions, 30-character max length, basic offensive word blocklist (~20 words with substring matching), 200-word wall cap with eviction (lowest votes first, then oldest). Vote tracking persisted in localStorage to survive page refreshes.

**Integration** — Replaces the Word Wall placeholder from PR #74. Navigable via `#/wordwall` route and the Word Wall button on the Stage.

## Files changed

- `demo/src/components/WordWall.tsx` — Main component: document init, submission, voting, cooldown
- `demo/src/components/WordCloud.tsx` — Tag cloud renderer with scaled fonts and colors
- `demo/src/lib/wordwall.ts` — Utilities: parsing, slugging, filtering, eviction, font sizing
- `demo/src/App.tsx` — Replace placeholder with real WordWall component

## Test results

TypeScript type-check and Vite build both pass with zero errors.