### PR TITLE
fix(demo): resolve critical UX bugs in LocalWrite

### DIFF
--- a/demo/src/components/Cursors.tsx
+++ b/demo/src/components/Cursors.tsx
@@ -120,6 +120,12 @@ export function Cursors({ synckit, pageId }: CursorProps) {
 
     return () => {
       mounted = false;
+
+      // Send leave update to remove user from room count
+      if (awarenessRef.current) {
+        awarenessRef.current.setLocalState(null).catch(() => {});
+      }
+
       if (cleanup) {
         cleanup.then(fn => fn && fn());
       }

--- a/demo/src/components/Editor.tsx
+++ b/demo/src/components/Editor.tsx
@@ -799,10 +799,12 @@ export function Editor({ pageId }: EditorProps) {
             newElement.appendChild(selectedContent);
             range.insertNode(newElement);
 
-            // Select the newly formatted text
-            range.selectNodeContents(newElement);
+            // Select the newly formatted text with a fresh range
+            // (the original range is stale after DOM mutations)
+            const newRange = document.createRange();
+            newRange.selectNodeContents(newElement);
             selection.removeAllRanges();
-            selection.addRange(range);
+            selection.addRange(newRange);
           }
         }
 

--- a/demo/src/components/Editor.tsx
+++ b/demo/src/components/Editor.tsx
@@ -81,9 +81,17 @@ export function Editor({ pageId }: EditorProps) {
   // Track subscription outside effect to prevent StrictMode duplicates
   const subscriptionRef = useRef<(() => void) | null>(null);
 
+  // Track document ref for cleanup (avoids stale closure bug)
+  const pageDocRef = useRef<SyncDocument<PageDocument> | null>(null);
+
   // Load page document when pageId changes
   useEffect(() => {
     if (!pageId) {
+      // Clear document ref and state
+      if (pageDocRef.current) {
+        (pageDocRef.current as any).dispose?.();
+        pageDocRef.current = null;
+      }
       setPageDoc(null);
       setPageData(null);
       setBlocks([]);
@@ -178,6 +186,8 @@ export function Editor({ pageId }: EditorProps) {
       // Store in ref to prevent duplicate subscriptions
       subscriptionRef.current = unsubscribe;
 
+      // Store in ref for cleanup (avoids stale closure)
+      pageDocRef.current = doc;
       setPageDoc(doc);
 
       // Set up auto-snapshots
@@ -219,11 +229,12 @@ export function Editor({ pageId }: EditorProps) {
       if (scheduler) scheduler.stop();
       if (snapshotInterval) clearInterval(snapshotInterval);
 
-      // CRITICAL: Dispose document to free memory (lazy loading)
-      // This prevents memory leaks when switching pages
-      if (pageDoc) {
+      // CRITICAL: Dispose document to unsubscribe and free memory
+      // Uses ref instead of state to avoid stale closure bug
+      if (pageDocRef.current) {
         console.log(`🧹 Disposing page document: ${pageId}`);
-        (pageDoc as any).dispose?.();
+        (pageDocRef.current as any).dispose?.();
+        pageDocRef.current = null;
       }
 
       setSnapshotScheduler(null);
@@ -800,7 +811,7 @@ export function Editor({ pageId }: EditorProps) {
             range.insertNode(newElement);
 
             // Select the newly formatted text with a fresh range
-            // (the original range is stale after DOM mutations)
+            // (the original range may be stale after DOM mutations)
             const newRange = document.createRange();
             newRange.selectNodeContents(newElement);
             selection.removeAllRanges();

--- a/server/typescript/src/index.ts
+++ b/server/typescript/src/index.ts
@@ -99,6 +99,8 @@ if (config.databaseUrl && !config.databaseUrl.includes('localhost')) {
   try {
     // console.log('🔌 Connecting to PostgreSQL...');
     await storage.connect();
+    // Ensure database schema exists (safe to run multiple times)
+    await storage.ensureSchema();
     storageConnected = true;
     // console.log('✅ PostgreSQL connected');
   } catch (error) {


### PR DESCRIPTION
## Summary
Fixes three critical bugs affecting the LocalWrite demo experience:

- **Cursor jump on formatting**: Cursor no longer jumps when applying bold/italic/code formatting
- **Room count persistence**: Users are properly unsubscribed when leaving a room
- **Word Wall data loss**: Database schema auto-migrates on server startup

## Changes

### ContentEditable.tsx
- Add `pendingLocalChangeRef` flag to track local DOM changes
- Skip DOM updates in useEffect when flag is set (DOM already correct)
- Prevents cursor corruption from redundant `updateDomWithCursorPreservation` calls

### Editor.tsx  
- Add `pageDocRef` to track document reference for cleanup
- Fixes stale closure bug where cleanup captured null `pageDoc`
- Documents now properly dispose on unmount

### Cursors.tsx
- Send awareness leave on component unmount

### postgres.ts + index.ts
- Add `ensureSchema()` method for auto-migration
- Server now verifies database tables exist on startup

## Test plan
- [x] Apply formatting (Ctrl+B) - cursor stays at end of word
- [x] Leave room - subscriber count decrements immediately
- [x] Word Wall persists after all tabs closed and reopened
- [x] Deployed and verified on https://localwrite-demo.fly.dev/