### PR TITLE
feat(demo): add typing indicators for live collaboration

### DIFF
--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -122,4 +122,21 @@
   .group:hover .drag-handle {
     @apply opacity-100;
   }
+
+  /* Typing indicator animation */
+  .typing-dot {
+    @apply text-white font-bold text-sm;
+    animation: typingDot 1.2s ease-in-out infinite;
+  }
+
+  @keyframes typingDot {
+    0%, 60%, 100% {
+      opacity: 0.3;
+      transform: translateY(0);
+    }
+    30% {
+      opacity: 1;
+      transform: translateY(-4px);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Adds real-time typing indicators that show when collaborators are actively typing
- Animated "..." bubble appears below other users' cursors when they type
- Auto-clears after 2.5 seconds of inactivity

## Changes

- **Cursors.tsx**: Extended awareness state with `typing` field, render typing bubble with staggered dot animation
- **Editor.tsx**: Fire typing events via awareness when content changes, with auto-clear timeout
- **index.css**: Added `typingDot` keyframe animation

## Test plan

- [ ] Open two browser tabs in the same room
- [ ] Type in tab 1
- [ ] Verify tab 2 shows "..." bubble near tab 1's cursor
- [ ] Stop typing and verify bubble disappears after ~2.5s
- [ ] Works in both light and dark mode

Part of UX enhancement epic (1 of 5 features)