### PR TITLE
feat(demo): add milestone celebrations with confetti and toasts

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -17,6 +17,8 @@ import {
   type AppRoute,
 } from './lib/rooms';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { ToastProvider } from './contexts/ToastContext';
+import { ToastContainer } from './components/Toast';
 import { initializeSyncKit } from './lib/synckit';
 import { StorageType } from './lib/storage';
 import { createPage, PageDocument, createBlock, BLOCK_TYPES } from './lib/blocks';
@@ -427,9 +429,12 @@ function App() {
 
   return (
     <ThemeProvider>
-      <SyncKitProvider synckit={synckit} storageType={storageType}>
-        <AppContent />
-      </SyncKitProvider>
+      <ToastProvider>
+        <SyncKitProvider synckit={synckit} storageType={storageType}>
+          <AppContent />
+          <ToastContainer />
+        </SyncKitProvider>
+      </ToastProvider>
     </ThemeProvider>
   );
 }

--- a/demo/src/components/Confetti.tsx
+++ b/demo/src/components/Confetti.tsx
@@ -1,0 +1,73 @@
+/**
+ * Confetti Component
+ * Pure CSS confetti animation for celebrations
+ */
+
+import { useEffect, useState } from 'react';
+
+interface ConfettiParticle {
+  id: number;
+  left: number;
+  color: string;
+  delay: number;
+  duration: number;
+  size: number;
+}
+
+const COLORS = [
+  '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4',
+  '#FFEAA7', '#DDA0DD', '#98D8C8', '#F7DC6F',
+  '#BB8FCE', '#85C1E9', '#F8B500', '#FF69B4',
+];
+
+function generateParticles(count: number): ConfettiParticle[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i,
+    left: Math.random() * 100,
+    color: COLORS[Math.floor(Math.random() * COLORS.length)],
+    delay: Math.random() * 0.5,
+    duration: 2 + Math.random() * 1,
+    size: 8 + Math.random() * 8,
+  }));
+}
+
+interface ConfettiProps {
+  onComplete?: () => void;
+}
+
+export function Confetti({ onComplete }: ConfettiProps) {
+  const [particles] = useState(() => generateParticles(50));
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setVisible(false);
+      onComplete?.();
+    }, 3500);
+
+    return () => clearTimeout(timeout);
+  }, [onComplete]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-0 pointer-events-none z-[99] overflow-hidden">
+      {particles.map((particle) => (
+        <div
+          key={particle.id}
+          className="absolute animate-confetti-fall"
+          style={{
+            left: `${particle.left}%`,
+            top: '-20px',
+            width: `${particle.size}px`,
+            height: `${particle.size}px`,
+            backgroundColor: particle.color,
+            borderRadius: Math.random() > 0.5 ? '50%' : '2px',
+            animationDelay: `${particle.delay}s`,
+            animationDuration: `${particle.duration}s`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/demo/src/components/Toast.tsx
+++ b/demo/src/components/Toast.tsx
@@ -1,0 +1,37 @@
+/**
+ * Toast Component
+ * Displays toast notifications with animations
+ */
+
+import { useToast } from '../contexts/ToastContext';
+
+export function ToastContainer() {
+  const { toasts, removeToast } = useToast();
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed top-4 right-4 z-[100] flex flex-col gap-2">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className={`
+            animate-toast-slide-in
+            flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg
+            min-w-[280px] max-w-[400px]
+            ${toast.variant === 'celebration'
+              ? 'bg-gradient-to-r from-amber-500 to-orange-500 text-white'
+              : 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-700'
+            }
+          `}
+          onClick={() => removeToast(toast.id)}
+        >
+          {toast.icon && (
+            <span className="text-2xl flex-shrink-0">{toast.icon}</span>
+          )}
+          <span className="font-medium">{toast.message}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/demo/src/contexts/ToastContext.tsx
+++ b/demo/src/contexts/ToastContext.tsx
@@ -1,0 +1,56 @@
+/**
+ * Toast Context
+ * Global toast notification state management
+ */
+
+import { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+
+export interface Toast {
+  id: string;
+  message: string;
+  icon?: string;
+  variant: 'default' | 'celebration';
+  duration: number;
+}
+
+interface ToastContextType {
+  toasts: Toast[];
+  addToast: (toast: Omit<Toast, 'id'>) => void;
+  removeToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextType | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const addToast = useCallback((toast: Omit<Toast, 'id'>) => {
+    const id = crypto.randomUUID();
+    const newToast = { ...toast, id };
+
+    setToasts((prev) => [...prev, newToast]);
+
+    // Auto-remove after duration
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, toast.duration);
+  }, []);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toasts, addToast, removeToast }}>
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+}

--- a/demo/src/hooks/useMilestoneTracker.ts
+++ b/demo/src/hooks/useMilestoneTracker.ts
@@ -1,0 +1,119 @@
+/**
+ * Milestone Tracker Hook
+ * Tracks word count milestones and triggers celebrations
+ */
+
+import { useEffect, useRef, useCallback } from 'react';
+import { Block } from '../lib/blocks';
+
+interface Milestone {
+  words: number;
+  emoji: string;
+  message: string;
+}
+
+const MILESTONES: Milestone[] = [
+  { words: 100, emoji: '🎯', message: 'First 100 words!' },
+  { words: 250, emoji: '📝', message: '250 words and counting!' },
+  { words: 500, emoji: '🚀', message: 'Halfway to 1000!' },
+  { words: 1000, emoji: '🎉', message: '1,000 words achieved!' },
+  { words: 2500, emoji: '🏆', message: '2,500 word milestone!' },
+  { words: 5000, emoji: '👑', message: 'Legendary: 5,000 words!' },
+];
+
+function countWords(text: string): number {
+  if (!text || text.trim() === '') return 0;
+  // Split on whitespace and filter empty strings
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function getStorageKey(pageId: string): string {
+  return `localwrite:milestones:${pageId}`;
+}
+
+function getAchievedMilestones(pageId: string): number[] {
+  try {
+    const stored = localStorage.getItem(getStorageKey(pageId));
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveAchievedMilestone(pageId: string, words: number): void {
+  try {
+    const achieved = getAchievedMilestones(pageId);
+    if (!achieved.includes(words)) {
+      achieved.push(words);
+      localStorage.setItem(getStorageKey(pageId), JSON.stringify(achieved));
+    }
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+interface UseMilestoneTrackerProps {
+  pageId: string | undefined;
+  blocks: Block[];
+  onMilestone: (milestone: Milestone) => void;
+}
+
+export function useMilestoneTracker({
+  pageId,
+  blocks,
+  onMilestone,
+}: UseMilestoneTrackerProps) {
+  const lastWordCountRef = useRef(0);
+  const initializedRef = useRef(false);
+
+  // Calculate total word count across all blocks
+  const calculateWordCount = useCallback(() => {
+    return blocks.reduce((total, block) => {
+      return total + countWords(block.content || '');
+    }, 0);
+  }, [blocks]);
+
+  useEffect(() => {
+    if (!pageId) return;
+
+    const currentWordCount = calculateWordCount();
+
+    // Skip initial mount to avoid false triggers
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      lastWordCountRef.current = currentWordCount;
+      return;
+    }
+
+    // Only check if word count increased
+    if (currentWordCount <= lastWordCountRef.current) {
+      lastWordCountRef.current = currentWordCount;
+      return;
+    }
+
+    const achieved = getAchievedMilestones(pageId);
+
+    // Check each milestone
+    for (const milestone of MILESTONES) {
+      // Milestone reached if:
+      // 1. Current count >= milestone
+      // 2. Previous count < milestone (just crossed)
+      // 3. Not already achieved
+      if (
+        currentWordCount >= milestone.words &&
+        lastWordCountRef.current < milestone.words &&
+        !achieved.includes(milestone.words)
+      ) {
+        saveAchievedMilestone(pageId, milestone.words);
+        onMilestone(milestone);
+        break; // Only trigger one milestone at a time
+      }
+    }
+
+    lastWordCountRef.current = currentWordCount;
+  }, [pageId, blocks, calculateWordCount, onMilestone]);
+
+  return {
+    wordCount: calculateWordCount(),
+  };
+}

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -139,4 +139,36 @@
       transform: translateY(-4px);
     }
   }
+
+  /* Toast animations */
+  .animate-toast-slide-in {
+    animation: toastSlideIn 0.3s ease-out;
+  }
+
+  @keyframes toastSlideIn {
+    from {
+      transform: translateX(100%);
+      opacity: 0;
+    }
+    to {
+      transform: translateX(0);
+      opacity: 1;
+    }
+  }
+
+  /* Confetti animation */
+  .animate-confetti-fall {
+    animation: confettiFall 3s ease-out forwards;
+  }
+
+  @keyframes confettiFall {
+    0% {
+      transform: translateY(0) rotate(0deg);
+      opacity: 1;
+    }
+    100% {
+      transform: translateY(100vh) rotate(720deg);
+      opacity: 0;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Celebrates word count milestones with confetti animation and toast notifications
- Milestones: 100, 250, 500, 1000, 2500, 5000 words
- Creates reusable Toast system for future features

## New Files

- **ToastContext.tsx**: Global toast state management
- **Toast.tsx**: Toast UI component with slide-in animation
- **Confetti.tsx**: CSS particle animation (50 particles)
- **useMilestoneTracker.ts**: Word counting and milestone detection

## Changes

- **App.tsx**: Added ToastProvider and ToastContainer
- **Editor.tsx**: Integrated milestone tracker, shows confetti on milestone
- **index.css**: Added toast and confetti animations

## Test plan

- [ ] Create new room, type until ~95 words
- [ ] Type 5 more words -> confetti + toast "First 100 words!"
- [ ] Refresh page -> no re-trigger (stored in localStorage)
- [ ] Continue to 250 -> new celebration
- [ ] Works in both light and dark mode

Part of UX enhancement epic (2 of 5 features)