### PR TITLE
feat(demo): add contribution stats dashboard

### DIFF
--- a/demo/src/components/ContributionStats.tsx
+++ b/demo/src/components/ContributionStats.tsx
@@ -1,0 +1,127 @@
+/**
+ * Contribution Stats Component
+ * Real-time dashboard showing words contributed per collaborator
+ */
+
+import { useState } from 'react';
+
+export interface ContributorData {
+  clientId: string;
+  userName: string;
+  userColor: string;
+  wordsAdded: number;
+  editsCount: number;
+}
+
+interface ContributionStatsProps {
+  contributors: ContributorData[];
+  localStats: { wordsAdded: number; editsCount: number };
+  localUserName: string;
+  localUserColor: string;
+}
+
+export function ContributionStats({
+  contributors,
+  localStats,
+  localUserName,
+  localUserColor,
+}: ContributionStatsProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Combine local user with remote contributors
+  const allContributors: ContributorData[] = [
+    {
+      clientId: 'local',
+      userName: `${localUserName} (you)`,
+      userColor: localUserColor,
+      wordsAdded: localStats.wordsAdded,
+      editsCount: localStats.editsCount,
+    },
+    ...contributors,
+  ];
+
+  // Sort by words added (descending)
+  const sortedContributors = [...allContributors].sort(
+    (a, b) => b.wordsAdded - a.wordsAdded
+  );
+
+  // Check if there are any contributions
+  const hasContributions = sortedContributors.some((c) => c.wordsAdded > 0 || c.editsCount > 0);
+
+  // Calculate totals
+  const totalWords = sortedContributors.reduce((sum, c) => sum + c.wordsAdded, 0);
+  const totalUsers = sortedContributors.filter((c) => c.wordsAdded > 0 || c.editsCount > 0).length;
+
+  if (!hasContributions) {
+    return null;
+  }
+
+  return (
+    <div className="fixed top-20 right-4 z-40">
+      {/* Compact badge */}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex items-center gap-2 px-3 py-2 bg-white dark:bg-gray-800 rounded-lg shadow-md border border-gray-200 dark:border-gray-700 hover:shadow-lg transition-shadow"
+      >
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {totalWords} words
+        </span>
+        {totalUsers > 1 && (
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            by {totalUsers} users
+          </span>
+        )}
+        <svg
+          className={`w-4 h-4 text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {/* Expanded panel */}
+      {isExpanded && (
+        <div className="mt-2 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 overflow-hidden animate-scale-in">
+          <div className="p-3 border-b border-gray-200 dark:border-gray-700">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              Contributions
+            </h3>
+          </div>
+
+          <div className="max-h-64 overflow-y-auto">
+            {sortedContributors.map((contributor, index) => (
+              <div
+                key={contributor.clientId}
+                className="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-700/50"
+              >
+                {/* Avatar dot */}
+                <div
+                  className="w-3 h-3 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: contributor.userColor }}
+                />
+
+                {/* Name and stats */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1">
+                    <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                      {contributor.userName}
+                    </span>
+                    {/* Crown for top contributor */}
+                    {index === 0 && contributor.wordsAdded > 0 && (
+                      <span className="animate-crown-bounce">👑</span>
+                    )}
+                  </div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                    {contributor.wordsAdded} words • {contributor.editsCount} edits
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/demo/src/components/Cursors.tsx
+++ b/demo/src/components/Cursors.tsx
@@ -23,6 +23,11 @@ interface TypingState {
   lastTypedAt: number;
 }
 
+interface ContributionState {
+  wordsAdded: number;
+  editsCount: number;
+}
+
 interface UserPresence {
   user?: {
     name: string;
@@ -30,6 +35,7 @@ interface UserPresence {
   };
   cursor?: CursorPosition | null;
   typing?: TypingState;
+  contributions?: ContributionState;
 }
 
 export function Cursors({ synckit, pageId }: CursorProps) {

--- a/demo/src/hooks/useContributionTracker.ts
+++ b/demo/src/hooks/useContributionTracker.ts
@@ -1,0 +1,77 @@
+/**
+ * Contribution Tracker Hook
+ * Tracks local user's contributions (words added, edits count)
+ */
+
+import { useEffect, useRef, useCallback, useState } from 'react';
+
+interface ContributionStats {
+  wordsAdded: number;
+  editsCount: number;
+}
+
+function countWords(text: string): number {
+  if (!text || text.trim() === '') return 0;
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+interface UseContributionTrackerProps {
+  pageId: string | undefined;
+  onContributionChange?: (stats: ContributionStats) => void;
+}
+
+export function useContributionTracker({
+  pageId,
+  onContributionChange,
+}: UseContributionTrackerProps) {
+  const [stats, setStats] = useState<ContributionStats>({
+    wordsAdded: 0,
+    editsCount: 0,
+  });
+
+  const lastContentRef = useRef<Map<string, string>>(new Map());
+  const statsRef = useRef(stats);
+
+  // Keep ref in sync
+  useEffect(() => {
+    statsRef.current = stats;
+  }, [stats]);
+
+  // Reset stats when page changes
+  useEffect(() => {
+    setStats({ wordsAdded: 0, editsCount: 0 });
+    lastContentRef.current.clear();
+  }, [pageId]);
+
+  // Track content change for a specific block
+  const trackContentChange = useCallback((blockId: string, newContent: string) => {
+    const lastContent = lastContentRef.current.get(blockId) || '';
+    const oldWords = countWords(lastContent);
+    const newWords = countWords(newContent);
+    const wordDiff = newWords - oldWords;
+
+    lastContentRef.current.set(blockId, newContent);
+
+    if (wordDiff !== 0 || newContent !== lastContent) {
+      setStats((prev) => {
+        const newStats = {
+          wordsAdded: prev.wordsAdded + Math.max(0, wordDiff),
+          editsCount: prev.editsCount + 1,
+        };
+        return newStats;
+      });
+    }
+  }, []);
+
+  // Notify changes (debounced in parent)
+  useEffect(() => {
+    if (onContributionChange) {
+      onContributionChange(stats);
+    }
+  }, [stats, onContributionChange]);
+
+  return {
+    stats,
+    trackContentChange,
+  };
+}

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -171,4 +171,19 @@
       opacity: 0;
     }
   }
+
+  /* Crown bounce animation */
+  .animate-crown-bounce {
+    display: inline-block;
+    animation: crownBounce 1s ease-in-out infinite;
+  }
+
+  @keyframes crownBounce {
+    0%, 100% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-3px);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Real-time leaderboard showing words contributed per collaborator
- Crown animation for top contributor
- Contributions broadcast via awareness API (debounced)

## New Files

- **useContributionTracker.ts**: Tracks words added and edit count per session
- **ContributionStats.tsx**: Collapsible dashboard UI with contributor list

## Changes

- **Cursors.tsx**: Extended awareness state with contributions field
- **Editor.tsx**: Integrated contribution tracker and stats panel
- **index.css**: Added crown bounce animation

## Test plan

- [ ] Open two tabs with different users in same room
- [ ] Type in both tabs
- [ ] Stats badge shows "X words by Y users"
- [ ] Click to expand - shows contributor list
- [ ] Crown appears next to top contributor
- [ ] Works in both light and dark mode

Part of UX enhancement epic (3 of 5 features)