### PR TITLE
feat(demo): add emoji reactions for text selections

### DIFF
--- a/demo/src/components/FloatingReaction.tsx
+++ b/demo/src/components/FloatingReaction.tsx
@@ -1,0 +1,40 @@
+/**
+ * Floating Reaction Component
+ * Animated emoji that floats up and fades out
+ */
+
+import { useEffect, useState } from 'react';
+
+interface FloatingReactionProps {
+  emoji: string;
+  position: { x: number; y: number };
+  onComplete: () => void;
+}
+
+export function FloatingReaction({ emoji, position, onComplete }: FloatingReactionProps) {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setVisible(false);
+      onComplete();
+    }, 2000);
+
+    return () => clearTimeout(timeout);
+  }, [onComplete]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="fixed pointer-events-none z-[100] animate-reaction-float text-4xl"
+      style={{
+        left: `${position.x}px`,
+        top: `${position.y}px`,
+        transform: 'translate(-50%, -50%)',
+      }}
+    >
+      {emoji}
+    </div>
+  );
+}

--- a/demo/src/components/ReactionPicker.tsx
+++ b/demo/src/components/ReactionPicker.tsx
@@ -1,0 +1,63 @@
+/**
+ * Reaction Picker Component
+ * Emoji selection popover for text reactions
+ */
+
+import { useState } from 'react';
+
+const REACTIONS = ['👍', '🎉', '🤔', '❤️', '🔥', '👏'];
+
+interface ReactionPickerProps {
+  position: { x: number; y: number };
+  onReact: (emoji: string) => void;
+  onClose: () => void;
+}
+
+export function ReactionPicker({ position, onReact, onClose }: ReactionPickerProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleReact = (emoji: string) => {
+    onReact(emoji);
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed z-[90] animate-scale-in"
+      style={{
+        left: `${position.x}px`,
+        top: `${position.y - 50}px`,
+        transform: 'translateX(-50%)',
+      }}
+    >
+      {isExpanded ? (
+        <div className="flex items-center gap-1 px-2 py-1 bg-white dark:bg-gray-800 rounded-full shadow-lg border border-gray-200 dark:border-gray-700">
+          {REACTIONS.map((emoji) => (
+            <button
+              key={emoji}
+              onClick={() => handleReact(emoji)}
+              className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-colors text-xl hover:scale-125 transform"
+            >
+              {emoji}
+            </button>
+          ))}
+          <button
+            onClick={onClose}
+            className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-colors text-gray-400"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setIsExpanded(true)}
+          className="flex items-center justify-center w-8 h-8 bg-white dark:bg-gray-800 rounded-full shadow-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+        >
+          <span className="text-sm">😀</span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -186,4 +186,24 @@
       transform: translateY(-3px);
     }
   }
+
+  /* Reaction float animation */
+  .animate-reaction-float {
+    animation: reactionFloat 2s ease-out forwards;
+  }
+
+  @keyframes reactionFloat {
+    0% {
+      transform: translate(-50%, -50%) scale(1);
+      opacity: 1;
+    }
+    50% {
+      transform: translate(-50%, calc(-50% - 40px)) scale(1.4);
+      opacity: 1;
+    }
+    100% {
+      transform: translate(-50%, calc(-50% - 80px)) scale(1);
+      opacity: 0;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Select text to show reaction button
- Click to expand emoji picker (6 options)
- Reactions float up and fade out over 2 seconds

## New Files

- **ReactionPicker.tsx**: Expandable emoji selection popover
- **FloatingReaction.tsx**: Animated floating emoji

## Changes

- **Editor.tsx**: Selection change detection, reaction state management
- **index.css**: Added reaction float animation

## Test plan

- [ ] Select text in any block
- [ ] Reaction button (emoji face) appears above selection
- [ ] Click to expand, shows 6 emoji options
- [ ] Click an emoji - it floats up and fades
- [ ] Works in both light and dark mode

Part of UX enhancement epic (4 of 5 features)