### PR TITLE
feat(demo): add time-lapse replay for document creation

### DIFF
--- a/demo/src/components/ReplayControls.tsx
+++ b/demo/src/components/ReplayControls.tsx
@@ -1,0 +1,131 @@
+/**
+ * Replay Controls Component
+ * Play/pause, speed, and timeline controls
+ */
+
+import { formatDuration } from '../lib/replay';
+import { PlaybackSpeed } from '../hooks/useReplayEngine';
+
+interface ReplayControlsProps {
+  isPlaying: boolean;
+  currentIndex: number;
+  totalOperations: number;
+  playbackSpeed: PlaybackSpeed;
+  elapsedMs: number;
+  totalMs: number;
+  onPlay: () => void;
+  onPause: () => void;
+  onSeek: (index: number) => void;
+  onRestart: () => void;
+  onSpeedChange: (speed: PlaybackSpeed) => void;
+  onClose: () => void;
+}
+
+const SPEEDS: PlaybackSpeed[] = [1, 2, 4, 8];
+
+export function ReplayControls({
+  isPlaying,
+  currentIndex,
+  totalOperations,
+  playbackSpeed,
+  elapsedMs,
+  totalMs,
+  onPlay,
+  onPause,
+  onSeek,
+  onRestart,
+  onSpeedChange,
+  onClose,
+}: ReplayControlsProps) {
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10);
+    onSeek(value - 1); // Convert to 0-based index
+  };
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-gray-900/95 text-white p-4 z-[101]">
+      <div className="max-w-3xl mx-auto">
+        {/* Timeline slider */}
+        <div className="mb-4">
+          <input
+            type="range"
+            min="0"
+            max={totalOperations}
+            value={currentIndex + 1}
+            onChange={handleSliderChange}
+            className="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-primary-500"
+          />
+          <div className="flex justify-between text-xs text-gray-400 mt-1">
+            <span>{formatDuration(elapsedMs)}</span>
+            <span>{formatDuration(totalMs)}</span>
+          </div>
+        </div>
+
+        {/* Controls */}
+        <div className="flex items-center justify-between">
+          {/* Left: Play controls */}
+          <div className="flex items-center gap-3">
+            {/* Restart button */}
+            <button
+              onClick={onRestart}
+              className="p-2 hover:bg-gray-700 rounded-lg transition-colors"
+              title="Restart"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+
+            {/* Play/Pause button */}
+            <button
+              onClick={isPlaying ? onPause : onPlay}
+              className="p-3 bg-primary-500 hover:bg-primary-600 rounded-full transition-colors"
+              title={isPlaying ? 'Pause' : 'Play'}
+            >
+              {isPlaying ? (
+                <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M6 4h4v16H6V4zm8 0h4v16h-4V4z" />
+                </svg>
+              ) : (
+                <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              )}
+            </button>
+
+            {/* Operation counter */}
+            <span className="text-sm text-gray-400">
+              {currentIndex + 1} / {totalOperations} edits
+            </span>
+          </div>
+
+          {/* Center: Speed selector */}
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-400">Speed:</span>
+            {SPEEDS.map((speed) => (
+              <button
+                key={speed}
+                onClick={() => onSpeedChange(speed)}
+                className={`px-3 py-1 rounded text-sm font-medium transition-colors ${
+                  playbackSpeed === speed
+                    ? 'bg-primary-500 text-white'
+                    : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                }`}
+              >
+                {speed}x
+              </button>
+            ))}
+          </div>
+
+          {/* Right: Close button */}
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors"
+          >
+            Exit Replay
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/demo/src/components/ReplayOverlay.tsx
+++ b/demo/src/components/ReplayOverlay.tsx
@@ -1,0 +1,125 @@
+/**
+ * Replay Overlay Component
+ * Full-screen document replay view
+ */
+
+import { useMemo } from 'react';
+import { ReplaySession } from '../lib/replay';
+import { ReplayControls } from './ReplayControls';
+import { useReplayEngine } from '../hooks/useReplayEngine';
+import { Block } from '../lib/blocks';
+import { parseMarkdown } from '../lib/markdown';
+
+interface ReplayOverlayProps {
+  session: ReplaySession;
+  blocks: Block[];
+  onClose: () => void;
+}
+
+export function ReplayOverlay({ session, blocks, onClose }: ReplayOverlayProps) {
+  const {
+    isPlaying,
+    currentIndex,
+    currentState,
+    currentOperation,
+    playbackSpeed,
+    totalOperations,
+    elapsedMs,
+    totalMs,
+    play,
+    pause,
+    seekTo,
+    restart,
+    setPlaybackSpeed,
+  } = useReplayEngine({ session });
+
+  // Get block order from the original blocks
+  const blockOrder = useMemo(() => blocks.map((b) => b.id), [blocks]);
+
+  // Get current active user (from the current operation)
+  const activeUser = currentOperation ? {
+    name: currentOperation.userName,
+    color: currentOperation.userColor,
+    blockId: currentOperation.blockId,
+  } : null;
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-black/80 flex flex-col">
+      {/* Header */}
+      <div className="bg-gray-900 px-6 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span className="text-2xl">🎬</span>
+          <div>
+            <h2 className="text-white font-semibold">Document Replay</h2>
+            <p className="text-gray-400 text-sm">
+              Watch how this document was created
+            </p>
+          </div>
+        </div>
+        {activeUser && (
+          <div className="flex items-center gap-2">
+            <div
+              className="w-3 h-3 rounded-full"
+              style={{ backgroundColor: activeUser.color }}
+            />
+            <span className="text-white text-sm">{activeUser.name} is typing...</span>
+          </div>
+        )}
+      </div>
+
+      {/* Document view */}
+      <div className="flex-1 overflow-y-auto bg-white dark:bg-gray-900 p-8">
+        <div className="max-w-3xl mx-auto">
+          {blockOrder.map((blockId) => {
+            const content = currentState[blockId] || '';
+            const isActive = activeUser?.blockId === blockId;
+            const block = blocks.find((b) => b.id === blockId);
+
+            if (!block) return null;
+
+            return (
+              <div
+                key={blockId}
+                className={`relative py-2 transition-all duration-200 ${
+                  isActive ? 'bg-yellow-50 dark:bg-yellow-900/20 -mx-4 px-4 rounded-lg' : ''
+                }`}
+              >
+                {/* Active indicator */}
+                {isActive && activeUser && (
+                  <div
+                    className="absolute -left-2 top-2 w-1 h-6 rounded-full"
+                    style={{ backgroundColor: activeUser.color }}
+                  />
+                )}
+
+                {/* Content */}
+                <div
+                  className="prose dark:prose-invert max-w-none"
+                  dangerouslySetInnerHTML={{
+                    __html: parseMarkdown(content) || '<span class="text-gray-400">Empty block</span>',
+                  }}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Controls */}
+      <ReplayControls
+        isPlaying={isPlaying}
+        currentIndex={currentIndex}
+        totalOperations={totalOperations}
+        playbackSpeed={playbackSpeed}
+        elapsedMs={elapsedMs}
+        totalMs={totalMs}
+        onPlay={play}
+        onPause={pause}
+        onSeek={seekTo}
+        onRestart={restart}
+        onSpeedChange={setPlaybackSpeed}
+        onClose={onClose}
+      />
+    </div>
+  );
+}

--- a/demo/src/hooks/useOperationRecorder.ts
+++ b/demo/src/hooks/useOperationRecorder.ts
@@ -1,0 +1,120 @@
+/**
+ * Operation Recorder Hook
+ * Records document editing operations for replay
+ */
+
+import { useEffect, useRef, useCallback } from 'react';
+import {
+  ReplaySession,
+  loadReplaySession,
+  saveReplaySession,
+  createReplaySession,
+  addOperation,
+} from '../lib/replay';
+import { Block } from '../lib/blocks';
+
+interface UseOperationRecorderProps {
+  pageId: string | undefined;
+  blocks: Block[];
+  userName: string;
+  userColor: string;
+}
+
+export function useOperationRecorder({
+  pageId,
+  blocks,
+  userName,
+  userColor,
+}: UseOperationRecorderProps) {
+  const sessionRef = useRef<ReplaySession | null>(null);
+  const lastContentRef = useRef<Map<string, string>>(new Map());
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Initialize or load session when page changes
+  useEffect(() => {
+    if (!pageId) {
+      sessionRef.current = null;
+      lastContentRef.current.clear();
+      return;
+    }
+
+    // Try to load existing session
+    let session = loadReplaySession(pageId);
+
+    if (!session) {
+      // Create new session with initial snapshot
+      const initialSnapshot: Record<string, string> = {};
+      blocks.forEach((block) => {
+        initialSnapshot[block.id] = block.content || '';
+        lastContentRef.current.set(block.id, block.content || '');
+      });
+      session = createReplaySession(pageId, initialSnapshot);
+    } else {
+      // Restore last content tracking
+      blocks.forEach((block) => {
+        lastContentRef.current.set(block.id, block.content || '');
+      });
+    }
+
+    sessionRef.current = session;
+
+    return () => {
+      // Save session on unmount
+      if (sessionRef.current) {
+        saveReplaySession(sessionRef.current);
+      }
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+    };
+  }, [pageId]); // Only depend on pageId, not blocks
+
+  // Record a content change (called from Editor)
+  const recordContentChange = useCallback((blockId: string, newContent: string) => {
+    if (!sessionRef.current) return;
+
+    const lastContent = lastContentRef.current.get(blockId) || '';
+
+    // Skip if no change
+    if (lastContent === newContent) return;
+
+    // For simplicity, record as a snapshot (full content)
+    // A more sophisticated implementation would compute insert/delete ops
+    addOperation(sessionRef.current, {
+      type: 'snapshot',
+      blockId,
+      content: newContent,
+      userId: 'local',
+      userName,
+      userColor,
+    });
+
+    lastContentRef.current.set(blockId, newContent);
+
+    // Debounced save
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+    saveTimeoutRef.current = setTimeout(() => {
+      if (sessionRef.current) {
+        saveReplaySession(sessionRef.current);
+      }
+    }, 2000);
+  }, [userName, userColor]);
+
+  // Get current session for replay
+  const getSession = useCallback((): ReplaySession | null => {
+    return sessionRef.current;
+  }, []);
+
+  // Check if there's a recording available
+  const hasRecording = useCallback((): boolean => {
+    return sessionRef.current !== null && sessionRef.current.operations.length > 0;
+  }, []);
+
+  return {
+    recordContentChange,
+    getSession,
+    hasRecording,
+  };
+}

--- a/demo/src/hooks/useReplayEngine.ts
+++ b/demo/src/hooks/useReplayEngine.ts
@@ -1,0 +1,163 @@
+/**
+ * Replay Engine Hook
+ * Plays back recorded operations
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { ReplaySession, reconstructState, RecordedOperation } from '../lib/replay';
+
+export type PlaybackSpeed = 1 | 2 | 4 | 8;
+
+interface UseReplayEngineProps {
+  session: ReplaySession | null;
+  onStateChange?: (state: Record<string, string>, operation: RecordedOperation | null) => void;
+}
+
+export function useReplayEngine({ session, onStateChange }: UseReplayEngineProps) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(-1);
+  const [playbackSpeed, setPlaybackSpeed] = useState<PlaybackSpeed>(1);
+  const [currentState, setCurrentState] = useState<Record<string, string>>({});
+
+  const animationRef = useRef<number | null>(null);
+  const lastUpdateRef = useRef<number>(0);
+
+  // Initialize state when session changes
+  useEffect(() => {
+    if (session) {
+      setCurrentIndex(-1);
+      setCurrentState(session.initialSnapshot);
+      setIsPlaying(false);
+    }
+  }, [session]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+    };
+  }, []);
+
+  // Calculate time between operations based on speed
+  const getIntervalMs = useCallback((speed: PlaybackSpeed): number => {
+    // Base interval is 200ms, speed multiplier reduces it
+    return 200 / speed;
+  }, []);
+
+  // Advance to next operation
+  const advanceToIndex = useCallback((index: number) => {
+    if (!session || index >= session.operations.length) {
+      setIsPlaying(false);
+      return;
+    }
+
+    const newState = reconstructState(session, index);
+    setCurrentState(newState);
+    setCurrentIndex(index);
+
+    if (onStateChange) {
+      const operation = index >= 0 ? session.operations[index] : null;
+      onStateChange(newState, operation);
+    }
+  }, [session, onStateChange]);
+
+  // Animation loop
+  useEffect(() => {
+    if (!isPlaying || !session) return;
+
+    const animate = (timestamp: number) => {
+      const interval = getIntervalMs(playbackSpeed);
+
+      if (timestamp - lastUpdateRef.current >= interval) {
+        const nextIndex = currentIndex + 1;
+
+        if (nextIndex >= session.operations.length) {
+          setIsPlaying(false);
+          return;
+        }
+
+        advanceToIndex(nextIndex);
+        lastUpdateRef.current = timestamp;
+      }
+
+      animationRef.current = requestAnimationFrame(animate);
+    };
+
+    lastUpdateRef.current = performance.now();
+    animationRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+    };
+  }, [isPlaying, session, currentIndex, playbackSpeed, getIntervalMs, advanceToIndex]);
+
+  // Controls
+  const play = useCallback(() => {
+    if (!session || session.operations.length === 0) return;
+
+    // If at end, restart from beginning
+    if (currentIndex >= session.operations.length - 1) {
+      setCurrentIndex(-1);
+      setCurrentState(session.initialSnapshot);
+    }
+
+    setIsPlaying(true);
+  }, [session, currentIndex]);
+
+  const pause = useCallback(() => {
+    setIsPlaying(false);
+  }, []);
+
+  const seekTo = useCallback((index: number) => {
+    if (!session) return;
+
+    const clampedIndex = Math.max(-1, Math.min(index, session.operations.length - 1));
+    advanceToIndex(clampedIndex);
+  }, [session, advanceToIndex]);
+
+  const restart = useCallback(() => {
+    if (!session) return;
+
+    setCurrentIndex(-1);
+    setCurrentState(session.initialSnapshot);
+    setIsPlaying(false);
+
+    if (onStateChange) {
+      onStateChange(session.initialSnapshot, null);
+    }
+  }, [session, onStateChange]);
+
+  // Computed values
+  const totalOperations = session?.operations.length || 0;
+  const progress = totalOperations > 0 ? (currentIndex + 1) / totalOperations : 0;
+  const currentOperation = session && currentIndex >= 0 ? session.operations[currentIndex] : null;
+
+  // Calculate elapsed and total time
+  const elapsedMs = session && currentIndex >= 0 && session.operations[currentIndex]
+    ? session.operations[currentIndex].timestamp - session.startTime
+    : 0;
+  const totalMs = session && session.operations.length > 0
+    ? session.operations[session.operations.length - 1].timestamp - session.startTime
+    : 0;
+
+  return {
+    isPlaying,
+    currentIndex,
+    currentState,
+    currentOperation,
+    playbackSpeed,
+    progress,
+    totalOperations,
+    elapsedMs,
+    totalMs,
+    play,
+    pause,
+    seekTo,
+    restart,
+    setPlaybackSpeed,
+  };
+}

--- a/demo/src/lib/replay.ts
+++ b/demo/src/lib/replay.ts
@@ -1,0 +1,131 @@
+/**
+ * Replay System - Core types and utilities
+ * Records and replays document editing sessions
+ */
+
+export interface RecordedOperation {
+  id: string;
+  timestamp: number;
+  type: 'insert' | 'delete' | 'snapshot';
+  blockId: string;
+  position?: number;
+  content?: string;
+  length?: number;
+  userId: string;
+  userName: string;
+  userColor: string;
+}
+
+export interface ReplaySession {
+  pageId: string;
+  startTime: number;
+  operations: RecordedOperation[];
+  initialSnapshot: Record<string, string>; // blockId -> content
+}
+
+const STORAGE_KEY_PREFIX = 'localwrite:replay:';
+const MAX_OPERATIONS = 500;
+const MAX_AGE_MS = 30 * 60 * 1000; // 30 minutes
+
+export function getStorageKey(pageId: string): string {
+  return `${STORAGE_KEY_PREFIX}${pageId}`;
+}
+
+export function loadReplaySession(pageId: string): ReplaySession | null {
+  try {
+    const stored = localStorage.getItem(getStorageKey(pageId));
+    if (!stored) return null;
+
+    const session = JSON.parse(stored) as ReplaySession;
+
+    // Check if session is too old
+    if (Date.now() - session.startTime > MAX_AGE_MS) {
+      localStorage.removeItem(getStorageKey(pageId));
+      return null;
+    }
+
+    return session;
+  } catch {
+    return null;
+  }
+}
+
+export function saveReplaySession(session: ReplaySession): void {
+  try {
+    // Trim operations if too many
+    if (session.operations.length > MAX_OPERATIONS) {
+      session.operations = session.operations.slice(-MAX_OPERATIONS);
+    }
+    localStorage.setItem(getStorageKey(session.pageId), JSON.stringify(session));
+  } catch {
+    // Storage full or other error - silently fail
+  }
+}
+
+export function clearReplaySession(pageId: string): void {
+  try {
+    localStorage.removeItem(getStorageKey(pageId));
+  } catch {
+    // Silently fail
+  }
+}
+
+export function createReplaySession(pageId: string, initialSnapshot: Record<string, string>): ReplaySession {
+  return {
+    pageId,
+    startTime: Date.now(),
+    operations: [],
+    initialSnapshot,
+  };
+}
+
+export function addOperation(session: ReplaySession, operation: Omit<RecordedOperation, 'id' | 'timestamp'>): void {
+  session.operations.push({
+    ...operation,
+    id: crypto.randomUUID(),
+    timestamp: Date.now(),
+  });
+}
+
+/**
+ * Reconstruct document state at a given operation index
+ */
+export function reconstructState(
+  session: ReplaySession,
+  upToIndex: number
+): Record<string, string> {
+  const state = { ...session.initialSnapshot };
+
+  for (let i = 0; i <= upToIndex && i < session.operations.length; i++) {
+    const op = session.operations[i];
+
+    if (op.type === 'snapshot') {
+      // Full snapshot replaces content
+      if (op.content !== undefined) {
+        state[op.blockId] = op.content;
+      }
+    } else if (op.type === 'insert' && op.content !== undefined && op.position !== undefined) {
+      const current = state[op.blockId] || '';
+      state[op.blockId] = current.slice(0, op.position) + op.content + current.slice(op.position);
+    } else if (op.type === 'delete' && op.position !== undefined && op.length !== undefined) {
+      const current = state[op.blockId] || '';
+      state[op.blockId] = current.slice(0, op.position) + current.slice(op.position + op.length);
+    }
+  }
+
+  return state;
+}
+
+/**
+ * Format duration for display
+ */
+export function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+
+  if (minutes > 0) {
+    return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
+  }
+  return `0:${remainingSeconds.toString().padStart(2, '0')}`;
+}


### PR DESCRIPTION
## Summary
- Implement the showstopper feature: time-lapse replay of document creation
- Records all editing operations with user info and timestamps
- Full-screen overlay with playback controls (1x/2x/4x/8x speeds)
- Timeline scrubber for seeking through the recording
- Shows active user with colored indicator during playback

## What's New

Added replay infrastructure in `lib/replay.ts` with types and utilities for recording operations. The `useOperationRecorder` hook captures content changes as snapshots, while `useReplayEngine` handles playback state and timing. UI is split between `ReplayControls` (play/pause, speed, timeline) and `ReplayOverlay` (full-screen view with document reconstruction).

## Test plan
- [ ] Create a new room and type some content
- [ ] Click the "Replay" button (appears after recording some edits)
- [ ] Verify full-screen overlay appears with document content
- [ ] Test play/pause functionality
- [ ] Test speed controls (1x, 2x, 4x, 8x)
- [ ] Test timeline scrubber for seeking
- [ ] Verify elapsed/total time displays correctly
- [ ] Test Exit Replay button closes overlay
- [ ] Works in dark mode