### PR TITLE
fix(demo): correct snapshot timestamp parsing for room documents

### DIFF
--- a/demo/src/components/SnapshotDialog.tsx
+++ b/demo/src/components/SnapshotDialog.tsx
@@ -58,8 +58,9 @@ export function SnapshotDialog({ scheduler, document, onClose }: SnapshotDialogP
 
   const formatTimestamp = (key: string): string => {
     // Extract timestamp from key: "snapshot:docId:timestamp"
+    // Note: docId may contain colons (e.g., "room:abc123"), so use last segment
     const parts = key.split(':');
-    const timestamp = parseInt(parts[2] || '0', 10);
+    const timestamp = parseInt(parts[parts.length - 1] || '0', 10);
 
     if (!timestamp) return 'Unknown time';
 


### PR DESCRIPTION
## Summary

Fixes snapshot timestamps displaying as "20488d ago (Jan 1, 3:00 AM)" instead of the actual time.

## Root Cause

Document IDs for rooms contain colons (e.g., `room:abc123`), so snapshot keys look like:
```
snapshot:room:abc123:1707123456789
```

The parser was using `parts[2]` which grabbed the roomId (`abc123`) instead of the timestamp. `parseInt("abc123")` returns `NaN`, causing `new Date(NaN)` to display epoch time.

## Fix

Extract timestamp from the **last** segment instead of hardcoded index:
```javascript
// Before
const timestamp = parseInt(parts[2] || '0', 10);

// After  
const timestamp = parseInt(parts[parts.length - 1] || '0', 10);
```

## Testing

- [x] Build passes
- [x] Logic verified: last segment is always the timestamp regardless of colons in docId