### PR TITLE
feat(demo): add onboarding hints for new visitors

### DIFF
--- a/demo/src/components/Editor.tsx
+++ b/demo/src/components/Editor.tsx
@@ -68,6 +68,7 @@ export function Editor({ pageId }: EditorProps) {
   const [reactionPicker, setReactionPicker] = useState<{ x: number; y: number } | null>(null);
   const [floatingReactions, setFloatingReactions] = useState<Array<{ id: string; emoji: string; position: { x: number; y: number } }>>([]);
   const [showReplay, setShowReplay] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
   const [awarenessReady, setAwarenessReady] = useState(false);
   const [liveContent, setLiveContent] = useState<Map<string, string>>(new Map());
   const editorRef = useRef<HTMLDivElement>(null);
@@ -1557,6 +1558,77 @@ export function Editor({ pageId }: EditorProps) {
           blocks={blocks}
           onClose={() => setShowReplay(false)}
         />
+      )}
+
+      {/* Help Button (floating) */}
+      <button
+        onClick={() => setShowHelp(true)}
+        className="fixed bottom-6 right-6 w-10 h-10 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-600 dark:text-gray-300 rounded-full shadow-lg flex items-center justify-center transition-all hover:scale-110 active:scale-95 z-30"
+        title="Keyboard shortcuts"
+      >
+        <span className="text-lg font-semibold">?</span>
+      </button>
+
+      {/* Help Modal */}
+      {showHelp && (
+        <>
+          <div
+            className="fixed inset-0 bg-black/30 dark:bg-black/50 z-40"
+            onClick={() => setShowHelp(false)}
+          />
+          <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-sm">
+            <div className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl border border-gray-200 dark:border-gray-700 p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                  Keyboard Shortcuts
+                </h3>
+                <button
+                  onClick={() => setShowHelp(false)}
+                  className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              <div className="space-y-3 text-sm">
+                <div className="flex justify-between items-center">
+                  <span className="text-gray-600 dark:text-gray-400">Block types</span>
+                  <kbd className="px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-gray-800 dark:text-gray-200 font-mono">/</kbd>
+                </div>
+                <div className="flex justify-between items-center">
+                  <span className="text-gray-600 dark:text-gray-400">Bold</span>
+                  <kbd className="px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-gray-800 dark:text-gray-200 font-mono">Ctrl+B</kbd>
+                </div>
+                <div className="flex justify-between items-center">
+                  <span className="text-gray-600 dark:text-gray-400">Italic</span>
+                  <kbd className="px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-gray-800 dark:text-gray-200 font-mono">Ctrl+I</kbd>
+                </div>
+                <div className="flex justify-between items-center">
+                  <span className="text-gray-600 dark:text-gray-400">Code</span>
+                  <kbd className="px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-gray-800 dark:text-gray-200 font-mono">Ctrl+E</kbd>
+                </div>
+                <div className="flex justify-between items-center">
+                  <span className="text-gray-600 dark:text-gray-400">Link</span>
+                  <kbd className="px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-gray-800 dark:text-gray-200 font-mono">Ctrl+K</kbd>
+                </div>
+                <hr className="border-gray-200 dark:border-gray-700" />
+                <div className="flex justify-between items-center">
+                  <span className="text-gray-600 dark:text-gray-400">New block</span>
+                  <kbd className="px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-gray-800 dark:text-gray-200 font-mono">Enter</kbd>
+                </div>
+                <div className="flex justify-between items-center">
+                  <span className="text-gray-600 dark:text-gray-400">Delete block</span>
+                  <kbd className="px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-gray-800 dark:text-gray-200 font-mono">Backspace</kbd>
+                </div>
+                <hr className="border-gray-200 dark:border-gray-700" />
+                <p className="text-xs text-gray-500 dark:text-gray-400 pt-1">
+                  Paste images directly • Drag blocks to reorder
+                </p>
+              </div>
+            </div>
+          </div>
+        </>
       )}
     </div>
   );

--- a/demo/src/components/Stage.tsx
+++ b/demo/src/components/Stage.tsx
@@ -195,6 +195,18 @@ export function Stage({ isConnected }: StageProps) {
         </div>
       </div>
 
+      {/* Hint for new visitors */}
+      <div className="max-w-4xl mx-auto px-4 pb-4">
+        <p className="text-center text-sm text-gray-500 dark:text-gray-400">
+          <span className="inline-flex items-center gap-1.5">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Open a room in two browser windows to see real-time sync
+          </span>
+        </p>
+      </div>
+
       {/* Action Buttons */}
       <div className="max-w-4xl mx-auto px-4 pb-10">
         <div className="flex flex-col sm:flex-row items-center justify-center gap-3">


### PR DESCRIPTION
## Summary

Adds subtle onboarding hints to help first-time visitors understand what to do and discover hidden features.

### Changes

**Stage page:**
- Added hint: "Open a room in two browser windows to see real-time sync"

**Editor:**
- Added floating "?" help button (bottom-right corner)
- Opens modal showing keyboard shortcuts: `/`, `Ctrl+B/I/E/K`, etc.

### Testing

- [x] Build passes
- [x] Deployed and verified