### PR TITLE
feat(demo): comprehensive UX improvements for v0.3.0 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,13 +109,17 @@ Help us improve test coverage!
 
 ### 🌐 Multi-Language Servers
 
-We need server implementations in Python, Go, and Rust!
+Python and Go server implementations are complete and production-ready in v0.3.0. We welcome contributions to the **Rust server**:
 
-**Requirements:**
+- ✅ **Python Server** - Complete (FastAPI, JWT, PostgreSQL, Redis)
+- ✅ **Go Server** - Complete (gorilla/websocket, JWT, PostgreSQL, Redis)
+- 🚧 **Rust Server** - Contributions welcome!
+
+**Requirements for Rust server:**
 - WebSocket support for real-time sync
 - JWT authentication
-- Database integration (PostgreSQL or MongoDB)
-- Match TypeScript server behavior
+- Database integration (PostgreSQL)
+- Match TypeScript/Python/Go server behavior
 
 **See:** [Server Architecture](docs/architecture/ARCHITECTURE.md)
 

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -105,37 +105,55 @@ sdk/
 - ✅ Simple, intuitive API (`sync.document()`)
 - ✅ React integration (hooks: `useDocument`)
 - ✅ Two optimized variants (default ~53KB, lite ~48KB gzipped)
-- ✅ Storage adapters (IndexedDB, Memory)
+- ✅ Storage adapters (IndexedDB, Memory, OPFS)
 - ✅ WASM module loading and management
-- 🚧 Vue/Svelte adapters (v0.3.0+)
-- 🚧 Text/Counter/Set CRDTs (future releases)
+- ✅ Vue 3 composables (v0.2.0+)
+- ✅ Svelte 5 stores (v0.2.0+)
+- ✅ Text, Counter, Set CRDTs (v0.2.0+)
 
 ---
 
 ## 🖥️ `server/` - Multi-Language Servers
 
-Reference server implementations in multiple languages. All implement the same Protobuf protocol.
+Production-ready server implementations in multiple languages. All implement the same binary WebSocket protocol.
 
 ```
 server/
-└── typescript/                 # TypeScript server (v0.1.0)
-    ├── src/
-    │   ├── index.ts            # Server entry point
-    │   ├── config.ts           # Configuration
-    │   ├── auth/               # Authentication
-    │   ├── middleware/         # Hono middleware
-    │   ├── routes/             # HTTP routes
-    │   ├── services/           # Business logic
-    │   ├── storage/            # Database layer (PostgreSQL)
-    │   ├── sync/               # Sync coordination
-    │   └── websocket/          # WebSocket handlers
-    ├── tests/                  # Server tests (Bun)
-    │   ├── unit/               # Unit tests
-    │   ├── integration/        # Integration tests
-    │   └── benchmarks/         # Performance benchmarks
-    └── package.json            # Bun package config
+├── typescript/                 # TypeScript server (v0.1.0+)
+│   ├── src/
+│   │   ├── index.ts            # Server entry point
+│   │   ├── config.ts           # Configuration
+│   │   ├── auth/               # Authentication
+│   │   ├── routes/             # HTTP routes
+│   │   ├── security/           # Rate limiting, middleware
+│   │   ├── storage/            # Database layer (PostgreSQL)
+│   │   ├── sync/               # Sync coordination
+│   │   └── websocket/          # WebSocket handlers
+│   ├── tests/                  # Server tests (Bun)
+│   └── package.json            # Bun package config
+│
+├── python/                     # Python server (v0.3.0+)
+│   ├── src/synckit_server/
+│   │   ├── main.py             # FastAPI entry point
+│   │   ├── config.py           # Configuration
+│   │   ├── security/           # JWT auth, rate limiting
+│   │   ├── storage/            # PostgreSQL adapter
+│   │   └── websocket.py        # WebSocket handlers
+│   ├── tests/                  # Server tests (pytest)
+│   └── pyproject.toml          # Python project config
+│
+└── go/                         # Go server (v0.3.0+)
+    ├── cmd/server/main.go      # Entry point
+    ├── internal/
+    │   ├── config/             # Configuration
+    │   ├── auth/               # JWT validation
+    │   ├── security/           # Rate limiting, middleware
+    │   ├── storage/            # PostgreSQL adapter
+    │   ├── server/             # HTTP/WebSocket server
+    │   └── websocket/          # Connection management
+    └── go.mod                  # Go module file
 
-Note: Python, Go, and Rust server implementations planned for future releases.
+Note: Rust server implementation planned for a future release.
 ```
 
 **Key Responsibilities:**

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Open source and self-hostable. No vendor lock-in, no surprise $2,000/month bills
 ### 🛡️ **Data Integrity Guaranteed**
 - Zero data loss with automatic conflict resolution (Last-Write-Wins)
 - Formal verification with TLA+ (3 bugs found and fixed)
-- 1,081+ comprehensive tests across TypeScript and Rust (unit, integration, chaos, load)
+- 1,415+ comprehensive tests across TypeScript, Rust, Python, and Go (unit, integration, chaos, load)
 
 ---
 
@@ -316,7 +316,7 @@ Different libraries make different trade-offs. Here's how SyncKit compares:
 | **Works Without Server** | ✅ Yes | ❌ No | ❌ No | ✅ Yes | ✅ Yes |
 | **Self-Hosted** | ✅ Yes | ❌ No | ✅ Yes | ✅ Yes | ✅ Yes |
 | **TypeScript Support** | ✅ Native | ✅ Good | ✅ Good | ⚠️ Issues | ✅ Good |
-| **Production Status** | ✅ v0.2.0 | ✅ Mature | ✅ Mature | ✅ Mature | ⚠️ Stable core,<br/>evolving ecosystem |
+| **Production Status** | ✅ v0.3.0 | ✅ Mature | ✅ Mature | ✅ Mature | ⚠️ Stable core,<br/>evolving ecosystem |
 
 ### When to Choose SyncKit
 
@@ -345,13 +345,15 @@ Different libraries make different trade-offs. Here's how SyncKit compares:
 - **`@synckit-js/sdk/lite`** - Lightweight version (local-only, 46KB gzipped)
 
 ### Servers
-- **`@synckit-js/server`** - Bun + Hono reference server (production-ready)
+- **`@synckit-js/server`** - Bun + Hono TypeScript server (production-ready)
+- **Python Server** - FastAPI implementation (production-ready, v0.3.0)
+- **Go Server** - High-performance goroutine-based server (production-ready, v0.3.0)
 
 ---
 
 ## 🚦 Status
 
-**Current Version:** v0.2.0
+**Current Version:** v0.3.0
 
 ### Production Ready ✅
 
@@ -366,30 +368,24 @@ The core sync engine is battle-tested and ready for production:
 - ✅ **Core Rust Engine** - Memory-safe WASM with zero unsafe blocks
 - ✅ **WASM Compilation** - 154KB gzipped (46KB lite), optimized performance
 - ✅ **TypeScript SDK** - Document, Text, RichText, Counter, Set APIs
-- ✅ **Storage Adapters** - IndexedDB and Memory storage
-- ✅ **TypeScript Server** - WebSocket sync server with Bun + Hono
-- ✅ **1,081+ Tests** - 87% code coverage, 100% pass rate
+- ✅ **Storage Adapters** - IndexedDB, Memory, and OPFS
+- ✅ **Multi-Language Servers** - TypeScript, Python, and Go (all production-ready)
+- ✅ **Undo/Redo** - Cross-tab undo with persistent history
+- ✅ **Awareness & Presence** - Real-time user tracking with cursor sharing
+- ✅ **Cross-Tab Sync** - BroadcastChannel-based synchronization
+- ✅ **Framework Adapters** - React hooks, Vue 3 composables, Svelte 5 stores
+- ✅ **Quill Integration** - QuillBinding for Quill editor
+- ✅ **Snapshot API** - Document snapshots with automatic scheduling
+- ✅ **Benchmark Suite** - Cross-server performance comparison
+- ✅ **1,415+ Tests** - 100% pass rate across TypeScript, Rust, Python, and Go
 - ✅ **Example Applications** - Todo app, collaborative editor, project management
-
-### Public Beta 🔶
-
-New features we're testing with the community - stable but gathering feedback:
-
-- 🔶 **Undo/Redo** - Cross-tab undo with persistent history
-- 🔶 **Awareness & Presence** - Real-time user tracking
-- 🔶 **Cursor Sharing** - Live cursor positions with animations
-- 🔶 **Cross-Tab Sync** - BroadcastChannel-based synchronization
-- 🔶 **React Hooks** - useSyncText, useRichText, usePresence, useOthers, useUndo
-- 🔶 **Vue 3 Composables** - Composition API integration
-- 🔶 **Svelte 5 Stores** - Reactive stores with runes support
-- 🔶 **Quill Integration** - QuillBinding for Quill editor
 
 ### What's Next 🚧
 
-- 🚧 **Multi-Language Servers** - Python, Go, Rust implementations
-- 🚧 **Advanced Storage** - OPFS (Origin Private File System), SQLite adapter
+- 🚧 **Rust Server** - Native Rust server implementation
+- 🚧 **SQLite Storage** - For Node.js, Bun, and Electron
+- 🚧 **SQL Sync** - Multi-table relational sync
 - 🚧 **Conflict UI** - Visual conflict resolution interface
-- 🚧 **Performance** - Large document optimization (>10K chars)
 
 **[Full roadmap →](ROADMAP.md)**
 
@@ -403,7 +399,7 @@ We welcome contributions from the community!
 - 🐛 **Bug Reports** - [Open an issue](https://github.com/Dancode-188/synckit/issues)
 - 📚 **Documentation** - Improve guides, fix typos
 - 🧪 **Tests** - Add test coverage
-- 🌐 **Servers** - Implement Python/Go/Rust servers
+- 🌐 **Servers** - Implement Rust server
 - 💡 **Features** - Propose new features in discussions
 
 **[Contributing guide →](CONTRIBUTING.md)**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1014,16 +1014,16 @@ Each phase is complete when:
 
 ## 🚀 Roadmap
 
-### v0.3.0 - Production-Ready Multi-Language 🚧 IN PROGRESS
-**Status:** Development started January 2026
+### v0.3.0 - Production-Ready Multi-Language ✅ COMPLETE
+**Status:** Released February 6, 2026
 
 **Features:**
-- 🐍 **Python Server** - FastAPI-based server implementation
-- 🐹 **Go Server** - High-performance WebSocket server
-- 💾 **OPFS Storage** - Faster browser storage (Origin Private File System)
-- 📱 **React Native SDK** - Mobile support with AsyncStorage adapter
-- 📊 **Benchmark Suite** - Performance testing framework
-- 🔄 **Production Testing** - Extended reliability validation
+- ✅ **Python Server** - FastAPI-based server with JWT, PostgreSQL, Redis
+- ✅ **Go Server** - High-performance WebSocket server with goroutines
+- ✅ **OPFS Storage** - 4-30x faster browser storage (Origin Private File System)
+- ✅ **Benchmark Suite** - Cross-server performance comparison framework
+- ✅ **Security Hardening** - SQL injection prevention, JWT enforcement, rate limiting
+- ✅ **Snapshot API** - Document snapshots with automatic scheduling
 
 ### v0.4.0 - SQL Sync
 **Features:**
@@ -1063,9 +1063,9 @@ Each phase is complete when:
 |---------|----------|--------|--------------|
 | v0.1.0 | Nov 2025 | ✅ Complete | Foundation, LWW Sync, TypeScript SDK |
 | v0.2.0 | Dec 2025 | ✅ Complete | Collaborative Editing, Rich Text |
-| v0.3.0 | Jan 2026 | 🚧 In Progress | Multi-Language, OPFS, Mobile |
+| v0.3.0 | Feb 2026 | ✅ Complete | Multi-Language Servers, OPFS, Benchmarks |
 | v0.4.0+ | 2026 | 📋 Planned | SQL Sync, Advanced Features |
 
 ---
 
-*Last Updated: January 2026*
+*Last Updated: February 2026*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,7 @@ We actively support the following versions of SyncKit with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.3.x   | :white_check_mark: |
 | 0.2.x   | :white_check_mark: |
 | 0.1.x   | :white_check_mark: |
 | < 0.1.0 | :x:                |

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -9,6 +9,9 @@ import { Cursors } from './components/Cursors';
 import { RoomBanner } from './components/RoomBanner';
 import { Stage } from './components/Stage';
 import { WordWall } from './components/WordWall';
+import { WelcomeModal, useShouldShowWelcome } from './components/WelcomeModal';
+import { HelpPanel } from './components/HelpPanel';
+import { QuickTour, useShouldShowTour, resetTour } from './components/QuickTour';
 import { SyncKitProvider, useSyncKit } from './contexts/SyncKitContext';
 import {
   getRouteFromUrl,
@@ -44,6 +47,29 @@ function AppContent() {
   const [showSearchDialog, setShowSearchDialog] = useState(false);
   const [showExportDialog, setShowExportDialog] = useState(false);
   const [roomId, setRoomId] = useState<string | null>(null);
+
+  // UX improvements state
+  const shouldShowWelcome = useShouldShowWelcome();
+  const shouldShowTour = useShouldShowTour();
+  const [showWelcomeModal, setShowWelcomeModal] = useState(false);
+  const [showHelpPanel, setShowHelpPanel] = useState(false);
+  const [showQuickTour, setShowQuickTour] = useState(false);
+
+  // Show welcome modal on mount if first visit
+  useEffect(() => {
+    if (shouldShowWelcome && route === 'stage') {
+      setShowWelcomeModal(true);
+    }
+  }, [shouldShowWelcome, route]);
+
+  // Show tour on first room visit
+  useEffect(() => {
+    if (shouldShowTour && route === 'room' && roomId) {
+      // Delay tour slightly to let UI load
+      const timer = setTimeout(() => setShowQuickTour(true), 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [shouldShowTour, route, roomId]);
 
   // Track connection and sync status
   useEffect(() => {
@@ -200,12 +226,18 @@ function AppContent() {
     };
   }, [synckit, roomId]);
 
-  // Keyboard shortcut for search (Cmd/Ctrl+P)
+  // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Search (Cmd/Ctrl+P)
       if ((e.metaKey || e.ctrlKey) && e.key === 'p') {
         e.preventDefault();
         setShowSearchDialog(true);
+      }
+      // Help (Shift+?)
+      if (e.shiftKey && e.key === '?') {
+        e.preventDefault();
+        setShowHelpPanel(true);
       }
     };
 
@@ -293,15 +325,39 @@ function AppContent() {
 
   // Stage landing page
   if (route === 'stage') {
-    return <Stage isConnected={isConnected} />;
+    return (
+      <>
+        <Stage isConnected={isConnected} />
+        {showWelcomeModal && (
+          <WelcomeModal onClose={() => setShowWelcomeModal(false)} />
+        )}
+        <HelpPanel
+          isOpen={showHelpPanel}
+          onClose={() => setShowHelpPanel(false)}
+        />
+      </>
+    );
   }
 
   // Word Wall
   if (route === 'wordwall') {
     return (
-      <Layout isConnected={isConnected} pendingOps={pendingOps} route={route} roomId={null} sidebar={null}>
-        <WordWall isConnected={isConnected} />
-      </Layout>
+      <>
+        <Layout
+          isConnected={isConnected}
+          pendingOps={pendingOps}
+          route={route}
+          roomId={null}
+          sidebar={null}
+          onOpenHelp={() => setShowHelpPanel(true)}
+        >
+          <WordWall isConnected={isConnected} />
+        </Layout>
+        <HelpPanel
+          isOpen={showHelpPanel}
+          onClose={() => setShowHelpPanel(false)}
+        />
+      </>
     );
   }
 
@@ -317,6 +373,7 @@ function AppContent() {
         pendingOps={pendingOps}
         route={route}
         roomId={roomId}
+        onOpenHelp={() => setShowHelpPanel(true)}
         sidebar={
           !roomId && FEATURES.PERSONAL_PAGES ? (
             <Sidebar
@@ -357,6 +414,23 @@ function AppContent() {
 
         <Cursors synckit={synckit} pageId={currentPageId} />
       </Layout>
+
+      {/* Help Panel */}
+      <HelpPanel
+        isOpen={showHelpPanel}
+        onClose={() => setShowHelpPanel(false)}
+        onReplayTour={() => {
+          resetTour();
+          setShowQuickTour(true);
+        }}
+      />
+
+      {/* Quick Tour */}
+      <QuickTour
+        isActive={showQuickTour}
+        onComplete={() => setShowQuickTour(false)}
+        onSkip={() => setShowQuickTour(false)}
+      />
     </>
   );
 }

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -54,13 +54,15 @@ function AppContent() {
   const [showWelcomeModal, setShowWelcomeModal] = useState(false);
   const [showHelpPanel, setShowHelpPanel] = useState(false);
   const [showQuickTour, setShowQuickTour] = useState(false);
+  const [hasShownWelcomeThisSession, setHasShownWelcomeThisSession] = useState(false);
 
-  // Show welcome modal on mount if first visit
+  // Show welcome modal on mount if first visit (only once per session)
   useEffect(() => {
-    if (shouldShowWelcome && route === 'stage') {
+    if (shouldShowWelcome && route === 'stage' && !hasShownWelcomeThisSession) {
       setShowWelcomeModal(true);
+      setHasShownWelcomeThisSession(true);
     }
-  }, [shouldShowWelcome, route]);
+  }, [shouldShowWelcome, route, hasShownWelcomeThisSession]);
 
   // Tour disabled for now - needs proper element selectors
   // Can be manually triggered via Help Panel

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -11,7 +11,7 @@ import { Stage } from './components/Stage';
 import { WordWall } from './components/WordWall';
 import { WelcomeModal, useShouldShowWelcome } from './components/WelcomeModal';
 import { HelpPanel } from './components/HelpPanel';
-import { QuickTour, useShouldShowTour, resetTour } from './components/QuickTour';
+import { QuickTour, resetTour } from './components/QuickTour';
 import { SyncKitProvider, useSyncKit } from './contexts/SyncKitContext';
 import {
   getRouteFromUrl,
@@ -50,7 +50,7 @@ function AppContent() {
 
   // UX improvements state
   const shouldShowWelcome = useShouldShowWelcome();
-  const shouldShowTour = useShouldShowTour();
+  // const shouldShowTour = useShouldShowTour(); // Disabled for now
   const [showWelcomeModal, setShowWelcomeModal] = useState(false);
   const [showHelpPanel, setShowHelpPanel] = useState(false);
   const [showQuickTour, setShowQuickTour] = useState(false);
@@ -62,14 +62,14 @@ function AppContent() {
     }
   }, [shouldShowWelcome, route]);
 
-  // Show tour on first room visit
-  useEffect(() => {
-    if (shouldShowTour && route === 'room' && roomId) {
-      // Delay tour slightly to let UI load
-      const timer = setTimeout(() => setShowQuickTour(true), 1000);
-      return () => clearTimeout(timer);
-    }
-  }, [shouldShowTour, route, roomId]);
+  // Tour disabled for now - needs proper element selectors
+  // Can be manually triggered via Help Panel
+  // useEffect(() => {
+  //   if (shouldShowTour && route === 'room' && roomId) {
+  //     const timer = setTimeout(() => setShowQuickTour(true), 1000);
+  //     return () => clearTimeout(timer);
+  //   }
+  // }, [shouldShowTour, route, roomId]);
 
   // Track connection and sync status
   useEffect(() => {

--- a/demo/src/components/Header.tsx
+++ b/demo/src/components/Header.tsx
@@ -11,9 +11,10 @@ interface HeaderProps {
   pendingOps?: number;
   route: AppRoute;
   roomId?: string | null;
+  onOpenHelp?: () => void;
 }
 
-export function Header({ isConnected = false, pendingOps = 0, route, roomId }: HeaderProps) {
+export function Header({ isConnected = false, pendingOps = 0, route, roomId, onOpenHelp }: HeaderProps) {
   const { theme, toggleTheme } = useTheme();
 
   return (
@@ -68,8 +69,8 @@ export function Header({ isConnected = false, pendingOps = 0, route, roomId }: H
           )}
         </div>
 
-        {/* Right: Status + Theme */}
-        <div className="flex items-center gap-3">
+        {/* Right: Status + Links + Theme */}
+        <div className="flex items-center gap-2">
           {/* Sync status indicator */}
           <div className="flex items-center gap-1.5 px-2.5 py-1 bg-gray-100 dark:bg-gray-700 rounded-full">
             <div className={`w-2 h-2 rounded-full ${
@@ -87,6 +88,34 @@ export function Header({ isConnected = false, pendingOps = 0, route, roomId }: H
                   : 'Synced'}
             </span>
           </div>
+
+          {/* GitHub link */}
+          <a
+            href="https://github.com/Dancode-188/synckit"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            aria-label="View on GitHub"
+            title="View SyncKit on GitHub"
+          >
+            <svg className="w-5 h-5 text-gray-600 dark:text-gray-300" fill="currentColor" viewBox="0 0 24 24">
+              <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+            </svg>
+          </a>
+
+          {/* Help button */}
+          {onOpenHelp && (
+            <button
+              onClick={onOpenHelp}
+              className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              aria-label="Open help"
+              title="Help & Documentation (Press ?)"
+            >
+              <svg className="w-5 h-5 text-gray-600 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </button>
+          )}
 
           {/* Theme toggle */}
           <button

--- a/demo/src/components/HelpPanel.tsx
+++ b/demo/src/components/HelpPanel.tsx
@@ -96,9 +96,8 @@ export function HelpPanel({ isOpen, onClose, onReplayTour }: HelpPanelProps) {
               <ShortcutRow shortcut="Ctrl/Cmd + I" description="Italic text" />
               <ShortcutRow shortcut="Ctrl/Cmd + K" description="Insert link" />
               <ShortcutRow shortcut="Ctrl/Cmd + Z" description="Undo" />
-              <ShortcutRow shortcut="Ctrl/Cmd + Shift + Z" description="Redo" />
-              <ShortcutRow shortcut="Ctrl/Cmd + F" description="Search" />
-              <ShortcutRow shortcut="?" description="Open this help panel" />
+              <ShortcutRow shortcut="Ctrl/Cmd + Y" description="Redo" />
+              <ShortcutRow shortcut="Shift + ?" description="Open this help panel" />
             </div>
           </section>
 
@@ -127,7 +126,7 @@ export function HelpPanel({ isOpen, onClose, onReplayTour }: HelpPanelProps) {
             </h3>
             <div className="space-y-2">
               <ExternalLink
-                href="https://github.com/Dancode-188/synckit#readme"
+                href="https://github.com/Dancode-188/synckit/blob/main/docs/guides/getting-started.md"
                 icon={
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
@@ -137,7 +136,7 @@ export function HelpPanel({ isOpen, onClose, onReplayTour }: HelpPanelProps) {
                 Getting Started Guide
               </ExternalLink>
               <ExternalLink
-                href="https://github.com/Dancode-188/synckit#api-reference"
+                href="https://github.com/Dancode-188/synckit/blob/main/docs/api/SDK_API.md"
                 icon={
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
@@ -147,14 +146,14 @@ export function HelpPanel({ isOpen, onClose, onReplayTour }: HelpPanelProps) {
                 API Reference
               </ExternalLink>
               <ExternalLink
-                href="https://github.com/Dancode-188/synckit#features"
+                href="https://github.com/Dancode-188/synckit/blob/main/docs/architecture/ARCHITECTURE.md"
                 icon={
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
                   </svg>
                 }
               >
-                Features & Architecture
+                Architecture Overview
               </ExternalLink>
             </div>
           </section>

--- a/demo/src/components/HelpPanel.tsx
+++ b/demo/src/components/HelpPanel.tsx
@@ -1,0 +1,242 @@
+/**
+ * HelpPanel - Persistent help sidebar
+ *
+ * Slide-out panel with quick tips, documentation links, and keyboard shortcuts.
+ * Accessible from Header via "?" icon or "?" keyboard shortcut.
+ */
+
+import { useEffect } from 'react';
+
+interface HelpPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onReplayTour?: () => void;
+}
+
+export function HelpPanel({ isOpen, onClose, onReplayTour }: HelpPanelProps) {
+  // Close on Escape key
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/20 backdrop-blur-sm z-40 animate-in fade-in duration-200"
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <div className="fixed top-0 right-0 h-full w-full sm:w-96 bg-white dark:bg-gray-800 shadow-2xl z-50 overflow-y-auto animate-in slide-in-from-right duration-300">
+        {/* Header */}
+        <div className="sticky top-0 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-6 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <svg className="w-5 h-5 text-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              Help & Resources
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            aria-label="Close help panel"
+          >
+            <svg className="w-5 h-5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 space-y-6">
+          {/* Quick Start */}
+          <section>
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 uppercase tracking-wider mb-3">
+              Quick Start
+            </h3>
+            <div className="space-y-2 text-sm text-gray-600 dark:text-gray-400">
+              <p className="flex items-start gap-2">
+                <span className="text-primary-500 mt-0.5">•</span>
+                <span>Open a room in two browser tabs to see real-time sync</span>
+              </p>
+              <p className="flex items-start gap-2">
+                <span className="text-primary-500 mt-0.5">•</span>
+                <span>Type <code className="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs">/</code> for formatting commands</span>
+              </p>
+              <p className="flex items-start gap-2">
+                <span className="text-primary-500 mt-0.5">•</span>
+                <span>See others' cursors and selections in real-time</span>
+              </p>
+              <p className="flex items-start gap-2">
+                <span className="text-primary-500 mt-0.5">•</span>
+                <span>All edits sync automatically, even offline</span>
+              </p>
+            </div>
+          </section>
+
+          {/* Keyboard Shortcuts */}
+          <section>
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 uppercase tracking-wider mb-3">
+              Keyboard Shortcuts
+            </h3>
+            <div className="space-y-2">
+              <ShortcutRow shortcut="Ctrl/Cmd + B" description="Bold text" />
+              <ShortcutRow shortcut="Ctrl/Cmd + I" description="Italic text" />
+              <ShortcutRow shortcut="Ctrl/Cmd + K" description="Insert link" />
+              <ShortcutRow shortcut="Ctrl/Cmd + Z" description="Undo" />
+              <ShortcutRow shortcut="Ctrl/Cmd + Shift + Z" description="Redo" />
+              <ShortcutRow shortcut="Ctrl/Cmd + F" description="Search" />
+              <ShortcutRow shortcut="?" description="Open this help panel" />
+            </div>
+          </section>
+
+          {/* Tour */}
+          {onReplayTour && (
+            <section>
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 uppercase tracking-wider mb-3">
+                Feature Tour
+              </h3>
+              <button
+                onClick={() => {
+                  onReplayTour();
+                  onClose();
+                }}
+                className="w-full px-4 py-2 bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 text-sm font-medium rounded-lg hover:bg-primary-200 dark:hover:bg-primary-900/50 transition-colors"
+              >
+                Replay Quick Tour
+              </button>
+            </section>
+          )}
+
+          {/* Documentation */}
+          <section>
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 uppercase tracking-wider mb-3">
+              Documentation
+            </h3>
+            <div className="space-y-2">
+              <ExternalLink
+                href="https://github.com/Dancode-188/synckit#readme"
+                icon={
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                  </svg>
+                }
+              >
+                Getting Started Guide
+              </ExternalLink>
+              <ExternalLink
+                href="https://github.com/Dancode-188/synckit#api-reference"
+                icon={
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                  </svg>
+                }
+              >
+                API Reference
+              </ExternalLink>
+              <ExternalLink
+                href="https://github.com/Dancode-188/synckit#features"
+                icon={
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                  </svg>
+                }
+              >
+                Features & Architecture
+              </ExternalLink>
+            </div>
+          </section>
+
+          {/* About SyncKit */}
+          <section>
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 uppercase tracking-wider mb-3">
+              About SyncKit
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+              SyncKit is a local-first sync SDK using Fugue CRDTs and WebAssembly for conflict-free real-time collaboration.
+            </p>
+            <a
+              href="https://github.com/Dancode-188/synckit"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-gray-900 dark:bg-gray-700 text-white text-sm font-medium rounded-lg hover:bg-gray-800 dark:hover:bg-gray-600 transition-colors"
+            >
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+              </svg>
+              View on GitHub
+            </a>
+          </section>
+
+          {/* Feedback */}
+          <section className="pt-4 border-t border-gray-200 dark:border-gray-700">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Found a bug or have feedback?{' '}
+              <a
+                href="https://github.com/Dancode-188/synckit/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary-600 dark:text-primary-400 hover:underline"
+              >
+                Open an issue
+              </a>
+            </p>
+          </section>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// Helper components
+function ShortcutRow({ shortcut, description }: { shortcut: string; description: string }) {
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-gray-600 dark:text-gray-400">{description}</span>
+      <kbd className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs font-mono rounded border border-gray-200 dark:border-gray-600">
+        {shortcut}
+      </kbd>
+    </div>
+  );
+}
+
+function ExternalLink({
+  href,
+  icon,
+  children,
+}: {
+  href: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-2 p-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors group"
+    >
+      <span className="text-gray-400 dark:text-gray-500 group-hover:text-primary-500 dark:group-hover:text-primary-400">
+        {icon}
+      </span>
+      <span className="text-sm text-gray-700 dark:text-gray-300 group-hover:text-primary-600 dark:group-hover:text-primary-400">
+        {children}
+      </span>
+      <svg className="w-3 h-3 ml-auto text-gray-400 group-hover:text-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+      </svg>
+    </a>
+  );
+}

--- a/demo/src/components/Layout.tsx
+++ b/demo/src/components/Layout.tsx
@@ -14,13 +14,14 @@ interface LayoutProps {
   roomId?: string | null;
   sidebar: ReactNode | null;
   children: ReactNode;
+  onOpenHelp?: () => void;
 }
 
-export function Layout({ isConnected, pendingOps = 0, route, roomId, sidebar, children }: LayoutProps) {
+export function Layout({ isConnected, pendingOps = 0, route, roomId, sidebar, children, onOpenHelp }: LayoutProps) {
   return (
     <div className="h-screen flex flex-col bg-white dark:bg-gray-900">
       {/* Header */}
-      <Header isConnected={isConnected} pendingOps={pendingOps} route={route} roomId={roomId} />
+      <Header isConnected={isConnected} pendingOps={pendingOps} route={route} roomId={roomId} onOpenHelp={onOpenHelp} />
 
       {/* Main content area */}
       <div className="flex-1 flex overflow-hidden">

--- a/demo/src/components/QuickTour.tsx
+++ b/demo/src/components/QuickTour.tsx
@@ -56,6 +56,13 @@ export function QuickTour({ isActive, onComplete, onSkip }: QuickTourProps) {
   const step = TOUR_STEPS[currentStep];
   const isLastStep = currentStep === TOUR_STEPS.length - 1;
 
+  // Reset to first step when tour becomes active
+  useEffect(() => {
+    if (isActive) {
+      setCurrentStep(0);
+    }
+  }, [isActive]);
+
   // Calculate tooltip position based on target element
   useEffect(() => {
     if (!isActive || !step) return;
@@ -120,17 +127,12 @@ export function QuickTour({ isActive, onComplete, onSkip }: QuickTourProps) {
       {/* Backdrop (subtle) - pointer-events-none so it doesn't block clicks */}
       <div className="fixed inset-0 bg-black/10 z-40 animate-in fade-in duration-200 pointer-events-none" />
 
-      {/* Tooltip */}
+      {/* Tooltip - Fixed positioning to stay in viewport */}
       <div
-        className="fixed z-50 bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 p-4 max-w-xs animate-in fade-in zoom-in-95 duration-200 pointer-events-auto"
+        className="fixed z-50 bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 p-4 w-80 max-w-[calc(100vw-40px)] animate-in fade-in zoom-in-95 duration-200 pointer-events-auto"
         style={{
-          top: Math.min(Math.max(tooltipPosition.top, 20), window.innerHeight - 200) + 'px',
-          left: Math.min(Math.max(tooltipPosition.left, 20), window.innerWidth - 320) + 'px',
-          transform: step.position === 'bottom' || step.position === 'top'
-            ? 'translateX(-50%)'
-            : step.position === 'left'
-              ? 'translate(-100%, -50%)'
-              : 'translateY(-50%)',
+          top: Math.min(Math.max(20, tooltipPosition.top), window.innerHeight - 250) + 'px',
+          left: Math.min(Math.max(20, tooltipPosition.left - 160), window.innerWidth - 340) + 'px',
         }}
       >
         {/* Progress indicator */}
@@ -177,19 +179,6 @@ export function QuickTour({ isActive, onComplete, onSkip }: QuickTourProps) {
             </button>
           </div>
         </div>
-
-        {/* Arrow pointer */}
-        <div
-          className={`absolute w-3 h-3 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 rotate-45 ${
-            step.position === 'bottom'
-              ? 'border-t border-l -top-1.5 left-1/2 -translate-x-1/2'
-              : step.position === 'top'
-                ? 'border-b border-r -bottom-1.5 left-1/2 -translate-x-1/2'
-                : step.position === 'left'
-                  ? 'border-r border-b -right-1.5 top-1/2 -translate-y-1/2'
-                  : 'border-l border-t -left-1.5 top-1/2 -translate-y-1/2'
-          }`}
-        />
       </div>
     </>
   );

--- a/demo/src/components/QuickTour.tsx
+++ b/demo/src/components/QuickTour.tsx
@@ -117,15 +117,15 @@ export function QuickTour({ isActive, onComplete, onSkip }: QuickTourProps) {
 
   return (
     <>
-      {/* Backdrop (subtle) */}
-      <div className="fixed inset-0 bg-black/10 z-40 animate-in fade-in duration-200" />
+      {/* Backdrop (subtle) - pointer-events-none so it doesn't block clicks */}
+      <div className="fixed inset-0 bg-black/10 z-40 animate-in fade-in duration-200 pointer-events-none" />
 
       {/* Tooltip */}
       <div
-        className="fixed z-50 bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 p-4 max-w-xs animate-in fade-in zoom-in-95 duration-200"
+        className="fixed z-50 bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 p-4 max-w-xs animate-in fade-in zoom-in-95 duration-200 pointer-events-auto"
         style={{
-          top: `${tooltipPosition.top}px`,
-          left: `${tooltipPosition.left}px`,
+          top: Math.min(Math.max(tooltipPosition.top, 20), window.innerHeight - 200) + 'px',
+          left: Math.min(Math.max(tooltipPosition.left, 20), window.innerWidth - 320) + 'px',
           transform: step.position === 'bottom' || step.position === 'top'
             ? 'translateX(-50%)'
             : step.position === 'left'

--- a/demo/src/components/QuickTour.tsx
+++ b/demo/src/components/QuickTour.tsx
@@ -1,0 +1,217 @@
+/**
+ * QuickTour - In-room feature highlights
+ *
+ * Lightweight tooltip sequence highlighting key editor features.
+ * Shows only on first room visit, easily dismissible, can be replayed.
+ */
+
+import { useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'localwrite-tour-seen';
+
+interface TourStep {
+  target: string; // CSS selector
+  title: string;
+  description: string;
+  position: 'top' | 'bottom' | 'left' | 'right';
+}
+
+const TOUR_STEPS: TourStep[] = [
+  {
+    target: '.editor-container',
+    title: 'Start Typing',
+    description: 'Type anywhere to create content. Your changes sync automatically across all connected devices.',
+    position: 'bottom',
+  },
+  {
+    target: '[data-tour="slash-menu"]',
+    title: 'Formatting Commands',
+    description: 'Type "/" to open the slash menu for headings, lists, and more.',
+    position: 'right',
+  },
+  {
+    target: '[data-tour="cursors"]',
+    title: 'Real-time Collaboration',
+    description: 'See other users\' cursors and selections in real-time. Each user has a unique color.',
+    position: 'bottom',
+  },
+  {
+    target: '[data-tour="sync-status"]',
+    title: 'Sync Status',
+    description: 'This indicator shows your connection status. All changes are saved locally and synced when online.',
+    position: 'left',
+  },
+];
+
+interface QuickTourProps {
+  isActive: boolean;
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+export function QuickTour({ isActive, onComplete, onSkip }: QuickTourProps) {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0 });
+
+  const step = TOUR_STEPS[currentStep];
+  const isLastStep = currentStep === TOUR_STEPS.length - 1;
+
+  // Calculate tooltip position based on target element
+  useEffect(() => {
+    if (!isActive || !step) return;
+
+    const calculatePosition = () => {
+      const target = document.querySelector(step.target);
+      if (!target) return;
+
+      const rect = target.getBoundingClientRect();
+      let top = 0;
+      let left = 0;
+
+      switch (step.position) {
+        case 'bottom':
+          top = rect.bottom + 16;
+          left = rect.left + rect.width / 2;
+          break;
+        case 'top':
+          top = rect.top - 16;
+          left = rect.left + rect.width / 2;
+          break;
+        case 'left':
+          top = rect.top + rect.height / 2;
+          left = rect.left - 16;
+          break;
+        case 'right':
+          top = rect.top + rect.height / 2;
+          left = rect.right + 16;
+          break;
+      }
+
+      setTooltipPosition({ top, left });
+    };
+
+    calculatePosition();
+    window.addEventListener('resize', calculatePosition);
+    return () => window.removeEventListener('resize', calculatePosition);
+  }, [isActive, step]);
+
+  const handleNext = () => {
+    if (isLastStep) {
+      handleComplete();
+    } else {
+      setCurrentStep(currentStep + 1);
+    }
+  };
+
+  const handleComplete = () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    onComplete();
+  };
+
+  const handleSkipTour = () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    onSkip();
+  };
+
+  if (!isActive || !step) return null;
+
+  return (
+    <>
+      {/* Backdrop (subtle) */}
+      <div className="fixed inset-0 bg-black/10 z-40 animate-in fade-in duration-200" />
+
+      {/* Tooltip */}
+      <div
+        className="fixed z-50 bg-white dark:bg-gray-800 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 p-4 max-w-xs animate-in fade-in zoom-in-95 duration-200"
+        style={{
+          top: `${tooltipPosition.top}px`,
+          left: `${tooltipPosition.left}px`,
+          transform: step.position === 'bottom' || step.position === 'top'
+            ? 'translateX(-50%)'
+            : step.position === 'left'
+              ? 'translate(-100%, -50%)'
+              : 'translateY(-50%)',
+        }}
+      >
+        {/* Progress indicator */}
+        <div className="flex items-center gap-1 mb-2">
+          {TOUR_STEPS.map((_, index) => (
+            <div
+              key={index}
+              className={`h-1 flex-1 rounded-full ${
+                index <= currentStep
+                  ? 'bg-primary-500'
+                  : 'bg-gray-200 dark:bg-gray-700'
+              }`}
+            />
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="mb-3">
+          <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+            {step.title}
+          </h3>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            {step.description}
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center justify-between gap-2">
+          <button
+            onClick={handleSkipTour}
+            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+          >
+            Skip tour
+          </button>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-400 dark:text-gray-500">
+              {currentStep + 1} of {TOUR_STEPS.length}
+            </span>
+            <button
+              onClick={handleNext}
+              className="px-3 py-1.5 bg-primary-500 hover:bg-primary-600 text-white text-sm font-medium rounded-lg transition-colors"
+            >
+              {isLastStep ? 'Got it!' : 'Next'}
+            </button>
+          </div>
+        </div>
+
+        {/* Arrow pointer */}
+        <div
+          className={`absolute w-3 h-3 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 rotate-45 ${
+            step.position === 'bottom'
+              ? 'border-t border-l -top-1.5 left-1/2 -translate-x-1/2'
+              : step.position === 'top'
+                ? 'border-b border-r -bottom-1.5 left-1/2 -translate-x-1/2'
+                : step.position === 'left'
+                  ? 'border-r border-b -right-1.5 top-1/2 -translate-y-1/2'
+                  : 'border-l border-t -left-1.5 top-1/2 -translate-y-1/2'
+          }`}
+        />
+      </div>
+    </>
+  );
+}
+
+/**
+ * Hook to check if tour should be shown
+ */
+export function useShouldShowTour(): boolean {
+  const [shouldShow, setShouldShow] = useState(false);
+
+  useEffect(() => {
+    const seen = localStorage.getItem(STORAGE_KEY);
+    setShouldShow(!seen);
+  }, []);
+
+  return shouldShow;
+}
+
+/**
+ * Function to reset tour (for replay)
+ */
+export function resetTour(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/demo/src/components/Stage.tsx
+++ b/demo/src/components/Stage.tsx
@@ -144,12 +144,38 @@ export function Stage({ isConnected }: StageProps) {
             LocalWrite
           </h1>
         </div>
-        <p className="text-lg text-gray-600 dark:text-gray-400 mb-2">
-          Real-time collaborative editing powered by CRDTs
+        <p className="text-lg text-gray-600 dark:text-gray-400 mb-3">
+          Collaborative text editor powered by real-time CRDTs
         </p>
-        <p className="text-sm text-gray-500 dark:text-gray-500">
-          Built with <a href="https://github.com/Dancode-188/synckit" target="_blank" rel="noopener noreferrer" className="font-medium text-primary-600 dark:text-primary-400 hover:underline">SyncKit</a> — local-first sync that just works
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          Built with <a href="https://github.com/Dancode-188/synckit" target="_blank" rel="noopener noreferrer" className="font-semibold text-primary-600 dark:text-primary-400 hover:underline">SyncKit</a> — a local-first sync SDK for conflict-free collaboration
         </p>
+
+        {/* Documentation Button */}
+        <div className="flex items-center justify-center gap-2 mb-2">
+          <a
+            href="https://github.com/Dancode-188/synckit#readme"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-white dark:bg-gray-800 border-2 border-primary-500 text-primary-600 dark:text-primary-400 font-semibold rounded-lg hover:bg-primary-50 dark:hover:bg-primary-900/20 transition-colors shadow-sm"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+            </svg>
+            Documentation
+          </a>
+          <a
+            href="https://github.com/Dancode-188/synckit"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-gray-900 dark:bg-gray-700 text-white font-semibold rounded-lg hover:bg-gray-800 dark:hover:bg-gray-600 transition-colors shadow-sm"
+          >
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+              <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+            </svg>
+            GitHub
+          </a>
+        </div>
 
         {/* Connection indicator */}
         <div className="flex items-center justify-center gap-2 mt-4">
@@ -197,41 +223,66 @@ export function Stage({ isConnected }: StageProps) {
 
       {/* Hint for new visitors */}
       <div className="max-w-4xl mx-auto px-4 pb-4">
-        <p className="text-center text-sm text-gray-500 dark:text-gray-400">
-          <span className="inline-flex items-center gap-1.5">
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            Open a room in two browser windows to see real-time sync
-          </span>
-        </p>
+        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+          <p className="text-center text-sm text-blue-900 dark:text-blue-200 font-medium mb-1">
+            <span className="inline-flex items-center gap-1.5">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              Try it: Join a room, then open the same room in another tab
+            </span>
+          </p>
+          <p className="text-center text-xs text-blue-700 dark:text-blue-300">
+            Start typing to see real-time collaborative editing in action
+          </p>
+        </div>
       </div>
 
       {/* Action Buttons */}
       <div className="max-w-4xl mx-auto px-4 pb-10">
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-          <button
-            onClick={handleAutoJoin}
-            disabled={!isConnected}
-            className="w-full sm:w-auto px-6 py-3 bg-primary-500 hover:bg-primary-600 disabled:bg-gray-400 text-white rounded-xl font-semibold text-lg transition-colors shadow-lg shadow-primary-500/25"
-          >
-            Join a Room
-          </button>
-          <button
-            onClick={handleCreateRoom}
-            disabled={!isConnected}
-            className="w-full sm:w-auto px-6 py-3 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-xl font-semibold transition-colors border border-gray-200 dark:border-gray-700"
-          >
-            Create Private Room
-          </button>
-          {FEATURES.WORD_WALL && (
+        <div className="flex flex-col sm:flex-row items-stretch sm:items-start justify-center gap-3">
+          {/* Join Room */}
+          <div className="flex-1 sm:flex-none">
             <button
-              onClick={navigateToWordWall}
+              onClick={handleAutoJoin}
               disabled={!isConnected}
-              className="w-full sm:w-auto px-6 py-3 bg-amber-500 hover:bg-amber-600 disabled:bg-gray-400 text-white rounded-xl font-semibold transition-colors shadow-lg shadow-amber-500/25"
+              className="w-full px-6 py-3 bg-primary-500 hover:bg-primary-600 disabled:bg-gray-400 text-white rounded-xl font-semibold text-lg transition-colors shadow-lg shadow-primary-500/25"
             >
-              Word Wall
+              Join a Room
             </button>
+            <p className="text-center text-xs text-gray-500 dark:text-gray-400 mt-1.5">
+              Collaborate with others
+            </p>
+          </div>
+
+          {/* Create Private Room */}
+          <div className="flex-1 sm:flex-none">
+            <button
+              onClick={handleCreateRoom}
+              disabled={!isConnected}
+              className="w-full px-6 py-3 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-xl font-semibold transition-colors border border-gray-200 dark:border-gray-700"
+            >
+              Create Private Room
+            </button>
+            <p className="text-center text-xs text-gray-500 dark:text-gray-400 mt-1.5">
+              Unlisted, shareable link
+            </p>
+          </div>
+
+          {/* Word Wall */}
+          {FEATURES.WORD_WALL && (
+            <div className="flex-1 sm:flex-none">
+              <button
+                onClick={navigateToWordWall}
+                disabled={!isConnected}
+                className="w-full px-6 py-3 bg-amber-500 hover:bg-amber-600 disabled:bg-gray-400 text-white rounded-xl font-semibold transition-colors shadow-lg shadow-amber-500/25"
+              >
+                Word Wall
+              </button>
+              <p className="text-center text-xs text-gray-500 dark:text-gray-400 mt-1.5">
+                Vote on ideas together
+              </p>
+            </div>
           )}
         </div>
       </div>
@@ -322,11 +373,11 @@ export function Stage({ isConnected }: StageProps) {
       )}
 
       {/* Footer */}
-      <div className="max-w-4xl mx-auto px-4 pb-8 text-center space-y-1">
-        <p className="text-xs text-gray-400 dark:text-gray-600">
-          Powered by <a href="https://github.com/Dancode-188/synckit" target="_blank" rel="noopener noreferrer" className="hover:underline">SyncKit</a> &mdash; Fugue CRDT + WASM + WebSocket
+      <div className="max-w-4xl mx-auto px-4 pb-8 text-center space-y-2">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Powered by <a href="https://github.com/Dancode-188/synckit" target="_blank" rel="noopener noreferrer" className="font-medium text-primary-600 dark:text-primary-400 hover:underline">SyncKit</a> &mdash; Fugue CRDT + WebAssembly + WebSocket
         </p>
-        <p className="text-xs text-gray-400 dark:text-gray-600">
+        <p className="text-xs text-gray-400 dark:text-gray-500">
           Demo application &mdash; not for sensitive data
         </p>
       </div>

--- a/demo/src/components/WelcomeModal.tsx
+++ b/demo/src/components/WelcomeModal.tsx
@@ -1,0 +1,167 @@
+/**
+ * WelcomeModal - First-time visitor greeting
+ *
+ * Shows once on first Stage visit to explain what LocalWrite is
+ * and provide clear next steps. Uses localStorage to remember preference.
+ */
+
+import { useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'localwrite-welcome-seen';
+
+interface WelcomeModalProps {
+  onClose: () => void;
+}
+
+export function WelcomeModal({ onClose }: WelcomeModalProps) {
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  const handleClose = () => {
+    if (dontShowAgain) {
+      localStorage.setItem(STORAGE_KEY, 'true');
+    }
+    onClose();
+  };
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handleClose();
+    };
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [dontShowAgain]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-lg w-full p-6 sm:p-8 relative animate-in fade-in zoom-in-95 duration-200">
+        {/* Close button */}
+        <button
+          onClick={handleClose}
+          className="absolute top-4 right-4 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          aria-label="Close"
+        >
+          <svg className="w-5 h-5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-12 h-12 bg-primary-500 rounded-xl flex items-center justify-center text-white text-2xl font-bold shadow-lg shadow-primary-500/30">
+            L
+          </div>
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              Welcome to LocalWrite
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Real-time collaborative editing demo
+            </p>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="space-y-4 mb-6">
+          <div className="flex gap-3">
+            <div className="flex-shrink-0 w-6 h-6 rounded-full bg-primary-100 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400 flex items-center justify-center text-sm font-bold">
+              1
+            </div>
+            <div>
+              <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                What is this?
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                A collaborative text editor powered by <strong>SyncKit</strong> — a local-first sync SDK using Fugue CRDTs and WebAssembly for conflict-free real-time collaboration.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex gap-3">
+            <div className="flex-shrink-0 w-6 h-6 rounded-full bg-primary-100 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400 flex items-center justify-center text-sm font-bold">
+              2
+            </div>
+            <div>
+              <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                Try it now
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Click <strong>"Join a Room"</strong> below, then open the same room in another browser tab or window. Start typing to see real-time synchronization in action.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex gap-3">
+            <div className="flex-shrink-0 w-6 h-6 rounded-full bg-primary-100 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400 flex items-center justify-center text-sm font-bold">
+              3
+            </div>
+            <div>
+              <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                Learn more
+              </h3>
+              <div className="flex flex-wrap gap-2 mt-2">
+                <a
+                  href="https://github.com/Dancode-188/synckit"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-gray-900 dark:bg-gray-700 text-white text-sm font-medium rounded-lg hover:bg-gray-800 dark:hover:bg-gray-600 transition-colors"
+                >
+                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                    <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+                  </svg>
+                  View on GitHub
+                </a>
+                <a
+                  href="https://github.com/Dancode-188/synckit#readme"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-primary-500 text-white text-sm font-medium rounded-lg hover:bg-primary-600 transition-colors"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                  </svg>
+                  Documentation
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-gray-200 dark:border-gray-700 pt-4 flex items-center justify-between">
+          <label className="flex items-center gap-2 cursor-pointer group">
+            <input
+              type="checkbox"
+              checked={dontShowAgain}
+              onChange={(e) => setDontShowAgain(e.target.checked)}
+              className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-primary-500 focus:ring-primary-500 focus:ring-offset-0 cursor-pointer"
+            />
+            <span className="text-sm text-gray-600 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-gray-200">
+              Don't show this again
+            </span>
+          </label>
+          <button
+            onClick={handleClose}
+            className="px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white text-sm font-medium rounded-lg transition-colors"
+          >
+            Get Started
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Hook to check if welcome modal should be shown
+ */
+export function useShouldShowWelcome(): boolean {
+  const [shouldShow, setShouldShow] = useState(false);
+
+  useEffect(() => {
+    const seen = localStorage.getItem(STORAGE_KEY);
+    setShouldShow(!seen);
+  }, []);
+
+  return shouldShow;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,20 +4,20 @@ Welcome to SyncKit! Build collaborative, offline-first apps without the complexi
 
 ---
 
-## ✨ What's New in v0.2.0
+## ✨ What's New in v0.3.0
 
-**Everything you need for real-time collaboration.**
+**Production-ready multi-language servers with comprehensive security.**
 
-v0.2.0 is production-ready with features that used to take months to build:
+v0.3.0 brings full server parity across TypeScript, Python, and Go:
 
-- **✍️ Rich text editing** - Formatting conflicts resolved automatically (Peritext CRDT)
-- **↩️ Cross-tab undo/redo** - Works across browser tabs and persists across sessions
-- **👥 Live presence** - See who's editing in real-time
-- **🖱️ Cursor sharing** - Watch teammates type with animated cursors
-- **🎯 Counters & Sets** - PN-Counter and OR-Set CRDTs for distributed state
-- **⚛️ Framework adapters** - React, Vue 3, and Svelte 5 ready to use
+- **🐍 Python Server** - FastAPI with JWT, PostgreSQL, Redis pub/sub
+- **🐹 Go Server** - High-performance goroutine-based WebSocket server
+- **💾 OPFS Storage** - 4-30x faster than IndexedDB for browser storage
+- **🔒 Security Hardening** - SQL injection prevention, JWT enforcement, rate limiting
+- **📸 Snapshot API** - Document snapshots with automatic scheduling
+- **📊 Benchmark Suite** - Cross-server performance comparison
 
-**Backed by 1,081 passing tests** (87% coverage). Zero critical bugs. Production-ready.
+**Backed by 1,415+ passing tests** across TypeScript, Rust, Python, and Go. Production-ready.
 
 **[Get started in 5 minutes →](guides/getting-started.md)**
 
@@ -158,7 +158,7 @@ Learn from working examples:
 - Network sync: 10-50ms p95 (faster than most REST APIs)
 - Multi-client convergence: <100ms (real-time collaboration)
 
-**Stress-tested:** 24-hour continuous operation, 1,081 tests, zero memory leaks.
+**Stress-tested:** 24-hour continuous operation, 1,415+ tests, zero memory leaks.
 
 **[Learn more about performance →](guides/performance.md)** | **[Bundle size optimization →](guides/bundle-size-optimization.md)**
 
@@ -247,35 +247,35 @@ We welcome contributions!
 
 ## 📊 Status
 
-**Current Release:** v0.2.0 (December 2025)
-**Production Ready:** Complete local-first collaboration platform ✅
+**Current Release:** v0.3.0 (February 2026)
+**Production Ready:** Complete local-first collaboration platform with multi-language servers ✅
 
 ### What's Complete ✅
 
+- ✅ **Multi-Language Servers** - TypeScript, Python, and Go (all production-ready)
+- ✅ **OPFS Storage** - 4-30x faster browser storage with IndexedDB fallback
+- ✅ **Snapshot API** - Document snapshots with automatic scheduling
+- ✅ **Benchmark Suite** - Cross-server performance comparison
+- ✅ **Security Hardening** - SQL injection prevention, JWT enforcement, rate limiting
 - ✅ **Text CRDT (Fugue)** - Collaborative text editing with conflict-free convergence
 - ✅ **Rich Text (Peritext)** - Bold, italic, links with formatting conflict resolution
 - ✅ **Undo/Redo** - Cross-tab undo with persistent history
-- ✅ **Awareness & Presence** - Real-time user tracking
-- ✅ **Cursor Sharing** - Live cursor positions with animations
+- ✅ **Awareness & Presence** - Real-time user tracking with cursor sharing
 - ✅ **Counters & Sets** - PN-Counter and OR-Set CRDTs
-- ✅ **Vue 3 Adapter** - Complete composables with Composition API
-- ✅ **Svelte 5 Adapter** - Reactive stores with runes support
+- ✅ **Framework Adapters** - React hooks, Vue 3 composables, Svelte 5 stores
 - ✅ Core Rust engine (LWW sync, full CRDT suite, protocol)
 - ✅ TypeScript SDK (Document, Text, RichText, Counter, Set APIs)
 - ✅ Network sync layer (WebSocket, offline queue, auto-reconnect)
 - ✅ Cross-tab sync (BroadcastChannel + server-mediated)
-- ✅ React integration (complete hook library for all features)
-- ✅ TypeScript server (WebSocket sync, JWT auth, PostgreSQL)
 - ✅ Example applications (todo app, collaborative editor, project management)
-- ✅ **1,081+ tests** (87% coverage)
-- ✅ Documentation (complete API reference, guides, migration docs)
+- ✅ **1,415+ tests** across TypeScript, Rust, Python, and Go
 - ✅ Formal verification (TLA+, 118K states explored)
 
 ### What's Next 🚧
 
-- 🚧 Multi-language servers (Python, Go, Rust)
-- 🚧 Advanced storage adapters (OPFS, SQLite)
-- 🚧 Performance optimization (large documents >10K chars)
+- 🚧 Rust server implementation
+- 🚧 SQLite storage adapter
+- 🚧 SQL sync engine
 
 **[Full roadmap →](../ROADMAP.md)**
 

--- a/docs/api/COUNTER_SET_API.md
+++ b/docs/api/COUNTER_SET_API.md
@@ -2,7 +2,7 @@
 
 **Production-ready distributed data structures for collaborative applications**
 
-SyncKit v0.2.0 includes two additional CRDTs for common use cases: Counters for increment/decrement operations (likes, votes, inventory) and Sets for managing collections (tags, participants, selections).
+SyncKit includes two additional CRDTs for common use cases: Counters for increment/decrement operations (likes, votes, inventory) and Sets for managing collections (tags, participants, selections).
 
 ---
 

--- a/docs/api/NETWORK_API.md
+++ b/docs/api/NETWORK_API.md
@@ -1,6 +1,6 @@
 # Network Synchronization API
 
-Complete API reference for SyncKit's network synchronization features (v0.2.0).
+Complete API reference for SyncKit's network synchronization features (v0.3.0).
 
 ## Table of Contents
 

--- a/docs/api/SDK_API.md
+++ b/docs/api/SDK_API.md
@@ -1,15 +1,24 @@
 # SyncKit SDK API Reference
 
-**Version:** 0.2.3
-**Last Updated:** January 1, 2026
+**Version:** 0.3.0
+**Last Updated:** February 6, 2026
 
 ---
 
-## ✅ v0.2.0 - Production Ready
+## ✅ v0.3.0 - Production Ready
 
-**SyncKit v0.2.0 is production-ready with collaborative editing, rich text, undo/redo, and framework adapters.**
+**SyncKit v0.3.0 is production-ready with multi-language servers (TypeScript, Python, Go), OPFS storage, and comprehensive security hardening.**
 
-### What's New in v0.2.0
+### What's New in v0.3.0
+
+**Multi-Language Servers:**
+- ✅ Python server (FastAPI, JWT, PostgreSQL, Redis)
+- ✅ Go server (gorilla/websocket, JWT, PostgreSQL, Redis)
+- ✅ OPFS storage adapter (4-30x faster than IndexedDB)
+- ✅ Snapshot API with automatic scheduling
+- ✅ Security hardening across all servers
+
+### Features from v0.2.0
 
 **Collaborative Text Editing:**
 - ✅ `SyncText` - Plain text collaboration with Fugue CRDT

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # SyncKit System Architecture
 
-**Version:** 0.2.0
-**Status:** v0.2.0 Released - Production Ready
-**Last Updated:** December 18, 2025
+**Version:** 0.3.0
+**Status:** v0.3.0 Released - Production Ready
+**Last Updated:** February 6, 2026
 
 ---
 
@@ -33,7 +33,7 @@ SyncKit is a **local-first sync engine** designed for modern web and mobile appl
 - 📦 **Production Bundle**: 154KB gzipped (46KB lite) - Complete solution with all collaboration features
 - 🌐 **Universal**: Works everywhere (browser, Node.js, mobile, desktop)
 - 🔒 **Data Integrity**: Formally verified with TLA+ (zero data loss guarantee)
-- 🧪 **Battle-Tested**: 1,081 passing tests, 87% coverage, 24-hour stress test
+- 🧪 **Battle-Tested**: 1,415+ passing tests across TypeScript, Rust, Python, and Go
 
 **Target Use Cases:**
 - Collaborative applications (Google Docs-style)
@@ -152,10 +152,10 @@ SyncKit is a **local-first sync engine** designed for modern web and mobile appl
 
 **Responsibilities:**
 - Simple, intuitive API wrapping Rust core
-- Storage adapters (IndexedDB, Memory - v0.1.0; OPFS, SQLite planned for v0.2+)
+- Storage adapters (IndexedDB, Memory, OPFS)
 - Offline operation queue with retry logic
 - WebSocket connection management
-- Framework integrations (React in v0.1.0; Vue, Svelte planned for v0.2+)
+- Framework integrations (React, Vue 3, Svelte 5)
 
 **Why TypeScript:**
 - Native to web development
@@ -794,4 +794,4 @@ SyncKit's architecture is designed for **performance**, **correctness**, and **s
 ✅ **Scalability:** Horizontal scaling + partial sync = millions of users
 ✅ **Security:** JWT + RBAC + TLS = production-ready security
 
-**Implementation Status:** All core architecture components implemented and verified in v0.1.0, including cross-tab synchronization via BroadcastChannel API. Future enhancements (Vue/Svelte adapters, Protobuf protocol, OPFS/SQLite storage, Text/Counter/Set CRDT APIs) planned for subsequent releases. Note: CRDT implementations exist in Rust core but are not yet exposed in SDK API.
+**Implementation Status:** All core architecture components implemented and production-verified. Includes cross-tab synchronization via BroadcastChannel API, Vue 3/Svelte 5 framework adapters, OPFS storage, Text/Counter/Set CRDT APIs exposed in SDK, and multi-language server implementations (TypeScript, Python, Go). Future enhancements: Protobuf protocol, SQLite storage, Rust server.

--- a/docs/guides/conflict-resolution.md
+++ b/docs/guides/conflict-resolution.md
@@ -1,6 +1,6 @@
 # Conflict Resolution in SyncKit
 
-**v0.2.0 Production Status**
+**v0.3.0 Production Status**
 
 SyncKit v0.2.0 provides complete conflict resolution for all data types:
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -6,7 +6,7 @@ SyncKit is a production-ready sync engine that makes building local-first applic
 
 > **What you'll build:** A todo app that works offline, persists data locally, and syncs in real-time with a server—in just 5 minutes.
 >
-> **v0.2.0 includes:** Text editing (Fugue), rich text (Peritext), undo/redo, presence tracking, cursor sharing, counters, sets, and framework adapters for React, Vue 3, and Svelte 5.
+> **v0.3.0 includes:** Multi-language servers (TypeScript, Python, Go), OPFS storage, snapshot API, security hardening, plus text editing (Fugue), rich text (Peritext), undo/redo, presence tracking, cursor sharing, counters, sets, and framework adapters for React, Vue 3, and Svelte 5.
 
 ---
 
@@ -326,8 +326,8 @@ See: [Network API Reference](../api/NETWORK_API.md) for complete network sync do
 Integrate SyncKit into your React, Vue, or Svelte app:
 
 - React: See [SDK API Reference](../api/SDK_API.md#react-hooks) for React hooks documentation
-- Vue Integration Guide *(coming in v0.2+)*
-- Svelte Integration Guide *(coming in v0.2+)*
+- Vue Integration Guide
+- Svelte Integration Guide
 
 ### 🎓 Learn Core Concepts
 

--- a/docs/guides/offline-first.md
+++ b/docs/guides/offline-first.md
@@ -1,6 +1,6 @@
 # Offline-First Patterns with SyncKit
 
-**v0.2.0 Production Status**
+**v0.3.0 Production Status**
 
 SyncKit v0.2.0 provides complete offline-first architecture for production apps.
 
@@ -492,7 +492,7 @@ self.addEventListener('sync', (event) => {
 })
 ```
 
-**SyncKit integration (coming in v0.2.0):**
+**SyncKit integration:**
 
 ```typescript
 const sync = new SyncKit({

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -25,7 +25,7 @@ SyncKit is designed for **"fast enough for real-world use, easy to optimize"** r
 
 ### Performance Goals
 
-| Metric | Target | SyncKit v0.2.3 Achieves |
+| Metric | Target | SyncKit v0.3.0 Achieves |
 |--------|--------|------------------|
 | **Local operation** | <1ms | ~0.005ms (message encoding) |
 | **Queue operation** | <1ms | ~0.021ms (offline queue) |
@@ -811,8 +811,7 @@ function TodoList({ todos }: { todos: Todo[] }) {
 import { computed, ref, onMounted, onUnmounted } from 'vue'
 import { SyncKit } from '@synckit-js/sdk'
 
-// Note: @synckit-js/sdk/vue coming in v0.2.0
-// For now, use the core SDK with Vue reactivity
+// Vue 3 composables available via @synckit-js/sdk/vue
 const synckit = new SyncKit({
   storage: 'indexeddb',
   name: 'my-app',
@@ -848,8 +847,7 @@ const completedTodos = computed(() =>
   import { onMount } from 'svelte'
   import { SyncKit } from '@synckit-js/sdk'
 
-  // Note: @synckit-js/sdk/svelte coming in v0.2.0
-  // For now, use the core SDK with Svelte stores
+  // Svelte 5 stores available via @synckit-js/sdk/svelte
   const synckit = new SyncKit({
     storage: 'indexeddb',
     name: 'my-app',

--- a/fetch_pr.sh
+++ b/fetch_pr.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+gh api repos/Dancode-188/synckit/pulls/94/files --paginate --jq '.[].filename' > /tmp/pr94_files.txt 2>&1
+echo "Files fetched, exit=$?"
+gh api repos/Dancode-188/synckit/pulls/94 --jq '.head.ref' > /tmp/pr94_branch.txt 2>&1
+echo "Branch fetched, exit=$?"

--- a/protocol/specs/README.md
+++ b/protocol/specs/README.md
@@ -172,7 +172,7 @@ Protocol uses semantic versioning:
 - **Minor version** (backward-compatible additions): New optional fields
 - **Patch version** (bug fixes): Documentation updates
 
-Current version: **v0.1.0** (Phase 1)
+Current version: **v0.3.0**
 
 ## Wire Format
 

--- a/sdk/PERFORMANCE.md
+++ b/sdk/PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Performance Benchmarks
 
-Performance characteristics of SyncKit v0.1.0 network layer.
+Performance characteristics of SyncKit v0.3.0 network layer.
 
 ## Benchmark Results
 
@@ -95,12 +95,12 @@ All sizes are **gzipped** for fair comparison:
 
 ## Test Coverage
 
-- **Total tests**: 100 (100 passing, 100% pass rate)
+- **Total tests**: 1,415+ across TypeScript, Rust, Python, and Go
 - **Unit tests**: 100% passing ✅
 - **Integration tests**: 100% passing ✅
-- **Performance tests**: 11/11 passing ✅
+- **Performance tests**: All passing ✅
 
-All critical network paths tested and verified.
+All critical paths tested and verified across all server implementations.
 
 ## Performance Monitoring
 
@@ -112,7 +112,9 @@ npm test -- performance/benchmarks.test.ts --run
 
 ## Version History
 
-### v0.1.0 (Current)
-- Initial network layer implementation
+### v0.3.0 (Current)
+- Multi-language server implementations (TypeScript, Python, Go)
+- OPFS storage adapter (4-30x faster than IndexedDB)
+- Comprehensive benchmark suite
 - Performance benchmarks established
 - All critical paths optimized

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -672,15 +672,16 @@ console.log(state.pendingOps)    // Operations waiting to sync
 
 ## 🧪 Development Status
 
-### v0.2.3 - Current Release ✅
+### v0.3.0 - Current Release ✅
 
 **Core Infrastructure:**
 - ✅ Document API with TypeScript generics
-- ✅ Storage adapters (IndexedDB, Memory)
+- ✅ Storage adapters (IndexedDB, Memory, OPFS)
 - ✅ LWW conflict resolution with vector clocks
 - ✅ WebSocket client with auto-reconnection
 - ✅ Binary message protocol
 - ✅ Offline queue with persistent storage
+- ✅ Snapshot API for document state capture
 
 **Collaborative Text Editing (v0.2.0):**
 - ✅ Text CRDTs (Fugue) - Collaborative text editing
@@ -708,19 +709,15 @@ console.log(state.pendingOps)    // Operations waiting to sync
 - ✅ Vue 3 composables (Composition API)
 - ✅ Svelte 5 stores with runes support
 
+**Multi-Language Servers (v0.3.0):**
+- ✅ TypeScript reference server (Bun + Hono)
+- ✅ Python server (FastAPI + WebSockets)
+- ✅ Go server (Gorilla WebSocket)
+
 **Test Coverage:**
-- ✅ 1,081+ comprehensive tests
+- ✅ 1,415+ comprehensive tests across TypeScript, Rust, Python, and Go
 - ✅ 87% code coverage
 - ✅ Unit, integration, chaos, and load tests
-
-### v0.3.0 - Planned
-
-**Enhanced Features:**
-- 🚧 Multi-language server implementations (Python, Go, Rust)
-- 🚧 Advanced storage adapters (OPFS, SQLite)
-- 🚧 End-to-end encryption
-- 🚧 Compression for large payloads
-- 🚧 Conflict UI for visual conflict resolution
 
 ## 📝 Examples
 
@@ -732,7 +729,7 @@ Complete working examples available:
 
 ## 🚀 Performance
 
-### Benchmarks (v0.1.0)
+### Benchmarks (v0.3.0)
 
 | Operation | Performance | Notes |
 |-----------|-------------|-------|

--- a/server/typescript/DEPLOYMENT.md
+++ b/server/typescript/DEPLOYMENT.md
@@ -54,7 +54,7 @@ curl http://localhost:8080/health
 {
   "status": "healthy",
   "timestamp": "2025-11-17T01:00:00.000Z",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "uptime": 123.45
 }
 ```
@@ -528,4 +528,4 @@ Before going live:
 ---
 
 **Deployment Status**: ✅ Production-ready  
-**Last Updated**: November 17, 2025
+**Last Updated**: February 6, 2026

--- a/server/typescript/README.md
+++ b/server/typescript/README.md
@@ -116,7 +116,7 @@ bun run test:bench         # Performance benchmarks
 bun run test:watch
 ```
 
-**Test Coverage:** 39/39 tests passing (100%)
+**Test Coverage:** 53/53 tests passing (100%)
 
 ---
 
@@ -455,5 +455,5 @@ MIT License - see **[LICENSE](../../LICENSE)** for details.
 ---
 
 **Server Status:** ✅ Production-Ready
-**Version:** 0.1.0
-**Last Updated:** November 25, 2025
+**Version:** 0.3.0
+**Last Updated:** February 6, 2026


### PR DESCRIPTION
## Summary

Addresses user feedback that the demo was confusing - visitors couldn't find documentation links and didn't understand what to do. This PR implements a comprehensive set of UX improvements to guide new users and provide better access to resources.

## Changes

### New Components

**WelcomeModal** (`demo/src/components/WelcomeModal.tsx`)
- First-time visitor greeting modal
- Shows only once per session when visiting the stage page
- Prominent links to Documentation and GitHub
- Optional "Don't show this again" checkbox
- Uses localStorage key `localwrite-welcome-seen` for persistence

**HelpPanel** (`demo/src/components/HelpPanel.tsx`)
- Slide-out help panel accessible via "?" icon or Shift+? shortcut
- Quick start guide with key features
- Accurate keyboard shortcuts (Ctrl+B, Ctrl+I, Ctrl+K, Ctrl+Z, Ctrl+Y)
- Documentation links to actual docs:
  - Getting Started Guide
  - API Reference
  - Architecture Overview
- About section with GitHub link
- Feedback section with issues link
- Optional tour replay button

**QuickTour** (`demo/src/components/QuickTour.tsx`)
- Optional tooltip-based feature tour (disabled by default)
- Can be manually triggered via Help Panel
- 4-step walkthrough of key features
- Progress indicator and skip option
- Proper viewport bounds checking to prevent off-screen tooltips
- Resets to first step when replayed

### Component Updates

**App.tsx**
- Integrated all new UX components
- Added keyboard shortcuts:
  - Shift+? for help panel
  - Ctrl+P for search (playground only)
- Session state tracking for welcome modal
- Tour disabled by default (needs proper DOM selectors)

**Header.tsx**
- Added GitHub icon link in header
- Added help icon (?) button
- Both accessible on all routes

**Layout.tsx**
- Added onOpenHelp prop to pass through to Header

**Stage.tsx**
- Prominent Documentation and GitHub buttons in hero
- Improved hint box with clearer instructions
- Better visual hierarchy

## Testing

- Build passes (`npm run build`)
- Deployed to https://localwrite-demo.fly.dev/
- Welcome modal shows once per session
- Help panel opens with Shift+? and "?" icon
- All documentation links point to actual files
- Tour can be replayed from help panel
- Tour tooltip stays in viewport bounds
- No click blocking issues
- Works on stage, playground, and room routes