### PR TITLE
chore: bump all package versions to v0.3.0

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synckit-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Daniel Bitengo"]
 description = "High-performance sync engine for local-first applications"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synckit-monorepo",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "private": true,
   "workspaces": [
     "sdk",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synckit-js/sdk",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Production-ready local-first sync with rich text editing, undo/redo, live cursors, and framework adapters for React, Vue, and Svelte",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/server/python/pyproject.toml
+++ b/server/python/pyproject.toml
@@ -2,7 +2,7 @@
 name = "synckit-server"
 version = "0.3.0"
 description = "SyncKit Python WebSocket Server - Production-ready sync server"
-authors = [{ name = "SyncKit Contributors" }]
+authors = [{ name = "Daniel Bitengo" }]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [

--- a/server/typescript/package.json
+++ b/server/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synckit-js/server",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "SyncKit WebSocket Server - Deploy as standalone service for real-time sync (Bun + Hono)",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synckit/tests",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps version to 0.3.0 across all package manifests for the v0.3.0 release

## Files Changed

- `package.json` (root monorepo): 0.2.3 -> 0.3.0
- `sdk/package.json`: 0.2.3 -> 0.3.0
- `server/typescript/package.json`: 0.2.3 -> 0.3.0
- `server/python/pyproject.toml`: author field update
- `core/Cargo.toml`: 0.2.0 -> 0.3.0
- `tests/package.json`: 0.1.0 -> 0.3.0

## Test plan

- [ ] Verify all package versions read 0.3.0