### PR TITLE
fix: address pre-release audit findings for v0.3.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -230,7 +230,6 @@ const todo = sync.document<Todo>('todo-1')
 ### Get Help
 
 - **📖 [Documentation](README.md)** - You are here!
-- **💬 [Discord Community](#)** - Chat with the community *(coming soon)*
 - **🐛 [GitHub Issues](https://github.com/Dancode-188/synckit/issues)** - Report bugs, request features
 - **📧 [Email](mailto:danbitengo@gmail.com)** - Direct support for enterprise
 
@@ -239,7 +238,7 @@ const todo = sync.document<Todo>('todo-1')
 We welcome contributions!
 
 - **[Contributing Guide](../CONTRIBUTING.md)** - How to contribute
-- **[Code of Conduct](../CODE_OF_CONDUCT.md)** - Community guidelines *(coming soon)*
+- **[Code of Conduct](../CODE_OF_CONDUCT.md)** - Community guidelines
 - **[Roadmap](../ROADMAP.md)** - Development timeline
 - **[Architecture Docs](architecture/ARCHITECTURE.md)** - Technical deep-dive
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -443,7 +443,6 @@ const todo = sync.document<Todo>('todo-1')
 Need assistance?
 
 - 📖 **[Documentation](../README.md)** - Comprehensive guides and API reference
-- 💬 **[Discord Community](#)** - Get help from the community *(coming soon)*
 - 🐛 **[GitHub Issues](https://github.com/Dancode-188/synckit/issues)** - Report bugs or request features
 - 📧 **[Email Support](mailto:danbitengo@gmail.com)** - Direct support for enterprise users
 

--- a/examples/collaborative-editor/package.json
+++ b/examples/collaborative-editor/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Real-time collaborative rich text editor built with SyncKit v0.2.0 and Quill",
+  "description": "Real-time collaborative rich text editor built with SyncKit and Quill",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/server/typescript/src/index.ts
+++ b/server/typescript/src/index.ts
@@ -25,7 +25,7 @@ const app = new Hono();
 // Middleware
 app.use('*', logger());
 app.use('*', cors({
-  origin: '*', // TODO: Configure in production
+  origin: process.env.CORS_ORIGIN || '*',
   credentials: true,
 }));
 
@@ -51,7 +51,7 @@ app.get('/health', (c) => {
   return c.json({
     status: 'healthy',
     timestamp: new Date().toISOString(),
-    version: '0.1.0',
+    version: '0.3.0',
     uptime: process.uptime(),
     connections: stats?.connections || { totalConnections: 0, totalUsers: 0, totalClients: 0 },
     documents: stats?.documents || { totalDocuments: 0, documents: [] },
@@ -62,7 +62,7 @@ app.get('/health', (c) => {
 app.get('/', (c) => {
   return c.json({
     name: 'SyncKit Server',
-    version: '0.1.0',
+    version: '0.3.0',
     description: 'Production-ready WebSocket sync server',
     endpoints: {
       health: '/health',


### PR DESCRIPTION
## Summary

Pre-release audit fixes found during final v0.3.0 review.

- Server health and info endpoints were reporting version 0.1.0 instead of 0.3.0
- CORS origin was hardcoded to `*` with a TODO comment; now configurable via `CORS_ORIGIN` env var
- Removed placeholder Discord Community links pointing to `#` (Discord not yet available)
- Removed "coming soon" marker from Code of Conduct link (file already exists)
- Removed version-pinned description from collaborative editor example

## Test plan

- [ ] `curl localhost:8080/health` returns `"version": "0.3.0"`
- [ ] `curl localhost:8080/` returns `"version": "0.3.0"`
- [ ] CORS respects `CORS_ORIGIN` env var when set
- [ ] No broken links in docs/README.md and docs/guides/getting-started.md