### PR TITLE
fix(ci): fix weekly benchmarks workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,16 +37,16 @@ jobs:
         run: mkdir -p core/target/criterion
 
       - name: Run LWW benchmarks
-        run: cd core && cargo bench --bench lww_bench | tee target/criterion/output.txt
+        run: cd core && cargo bench --bench lww_bench -- --output-format bencher | tee target/criterion/output.txt
 
       - name: Run Vector Clock benchmarks
-        run: cd core && cargo bench --bench vector_clock_bench | tee -a target/criterion/output.txt
+        run: cd core && cargo bench --bench vector_clock_bench -- --output-format bencher | tee -a target/criterion/output.txt
 
       - name: Run Delta benchmarks
-        run: cd core && cargo bench --bench delta_bench | tee -a target/criterion/output.txt
+        run: cd core && cargo bench --bench delta_bench -- --output-format bencher | tee -a target/criterion/output.txt
 
       - name: Run Fugue benchmarks
-        run: cd core && cargo bench --bench fugue_bench | tee -a target/criterion/output.txt
+        run: cd core && cargo bench --bench fugue_bench -- --output-format bencher | tee -a target/criterion/output.txt
 
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,6 +33,9 @@ jobs:
           path: ~/.cargo/git
           key: ubuntu-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Create output directory
+        run: mkdir -p core/target/criterion
+
       - name: Run LWW benchmarks
         run: cd core && cargo bench --bench lww_bench 2>&1 | tee target/criterion/output.txt
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,13 +34,16 @@ jobs:
           key: ubuntu-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run LWW benchmarks
-        run: cd core && cargo bench --bench lww_bench
+        run: cd core && cargo bench --bench lww_bench 2>&1 | tee target/criterion/output.txt
 
       - name: Run Vector Clock benchmarks
-        run: cd core && cargo bench --bench vector_clock_bench
+        run: cd core && cargo bench --bench vector_clock_bench 2>&1 | tee -a target/criterion/output.txt
 
       - name: Run Delta benchmarks
-        run: cd core && cargo bench --bench delta_bench
+        run: cd core && cargo bench --bench delta_bench 2>&1 | tee -a target/criterion/output.txt
+
+      - name: Run Fugue benchmarks
+        run: cd core && cargo bench --bench fugue_bench 2>&1 | tee -a target/criterion/output.txt
 
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:  # Allow manual trigger
 
+permissions:
+  contents: write
+
 env:
   CARGO_TERM_COLOR: auto
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,16 +37,16 @@ jobs:
         run: mkdir -p core/target/criterion
 
       - name: Run LWW benchmarks
-        run: cd core && cargo bench --bench lww_bench 2>&1 | tee target/criterion/output.txt
+        run: cd core && cargo bench --bench lww_bench | tee target/criterion/output.txt
 
       - name: Run Vector Clock benchmarks
-        run: cd core && cargo bench --bench vector_clock_bench 2>&1 | tee -a target/criterion/output.txt
+        run: cd core && cargo bench --bench vector_clock_bench | tee -a target/criterion/output.txt
 
       - name: Run Delta benchmarks
-        run: cd core && cargo bench --bench delta_bench 2>&1 | tee -a target/criterion/output.txt
+        run: cd core && cargo bench --bench delta_bench | tee -a target/criterion/output.txt
 
       - name: Run Fugue benchmarks
-        run: cd core && cargo bench --bench fugue_bench 2>&1 | tee -a target/criterion/output.txt
+        run: cd core && cargo bench --bench fugue_bench | tee -a target/criterion/output.txt
 
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:  # Allow manual trigger
 
 env:
-  CARGO_TERM_COLOR: always
+  CARGO_TERM_COLOR: auto
 
 jobs:
   benchmark:


### PR DESCRIPTION
## Summary
- Pipe cargo bench stdout to output file so benchmark-action can read and store results
- Add missing fugue_bench to the workflow
- Create output directory before first bench run
- Use CARGO_TERM_COLOR auto so color codes don't pollute the output file
- Pipe only stdout (not stderr) to avoid compilation noise in the output
- Use --output-format bencher so Criterion outputs in libtest format
- Add permissions contents write so the action can push results to gh-pages
- Create gh-pages branch for benchmark data storage

## Root Cause
Multiple issues prevented the Store benchmark results step from working. This has been failing every week since at least January 11 (5+ consecutive failures).

## Test plan
- [x] Triggered workflow manually -- all steps pass