### PR TITLE
fix(demo): remove misleading undo/redo shortcuts from help panel

### DIFF
--- a/demo/src/components/HelpPanel.tsx
+++ b/demo/src/components/HelpPanel.tsx
@@ -95,8 +95,6 @@ export function HelpPanel({ isOpen, onClose, onReplayTour }: HelpPanelProps) {
               <ShortcutRow shortcut="Ctrl/Cmd + B" description="Bold text" />
               <ShortcutRow shortcut="Ctrl/Cmd + I" description="Italic text" />
               <ShortcutRow shortcut="Ctrl/Cmd + K" description="Insert link" />
-              <ShortcutRow shortcut="Ctrl/Cmd + Z" description="Undo" />
-              <ShortcutRow shortcut="Ctrl/Cmd + Y" description="Redo" />
               <ShortcutRow shortcut="Shift + ?" description="Open this help panel" />
             </div>
           </section>


### PR DESCRIPTION
## Summary

- Remove Ctrl/Cmd+Z (Undo) and Ctrl/Cmd+Y (Redo) from the help panel keyboard shortcuts section
- The demo uses browser-native undo/redo, not the SDK's UndoManager
- Listing these shortcuts implied SyncKit-powered functionality that isn't implemented in the demo

## Context

Investigation revealed that the demo does not integrate the SDK's UndoManager or useUndo() hook. When users press Ctrl+Z/Y, the browser's built-in contentEditable undo fires, not SyncKit's cross-tab persistent undo system.

Rather than falsely advertising SDK-powered undo/redo, we remove these entries. Browser-native undo/redo still works as users expect. SDK undo/redo integration (with cross-tab sync and persistence) can be added in a future release.

## Changes

- `demo/src/components/HelpPanel.tsx`: Removed 2 ShortcutRow entries (Undo and Redo)

## Testing

- Build passes (npm run build)
- Deployed to https://localwrite-demo.fly.dev/ and verified
- Help panel displays remaining shortcuts correctly
- Browser-native Ctrl+Z/Y still works in the editor