### PR TITLE
docs: incorporate C# server into project documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Production-Ready Multi-Language Servers!**
 
-This release brings full server parity across TypeScript, Python, and Go, with comprehensive security hardening, OPFS storage, and a benchmark suite for cross-server performance comparison.
+This release brings full server parity across TypeScript, Python, Go, and C#, with comprehensive security hardening, OPFS storage, and a benchmark suite for cross-server performance comparison.
 
 ### Added
 
@@ -44,6 +44,17 @@ This release brings full server parity across TypeScript, Python, and Go, with c
   - UNSUBSCRIBE handler for protocol completeness
   - Periodic awareness cleanup to prevent memory leaks
   - Comprehensive test suite (51 tests)
+
+- **🔷 C# Server** - ASP.NET Core implementation (community-contributed by @matthewcorven)
+  - Full binary WebSocket protocol support with JSON and binary modes
+  - JWT authentication with RBAC (canRead/canWrite/isAdmin)
+  - PostgreSQL storage adapter
+  - Redis pub/sub for multi-server coordination
+  - Rate limiting, CORS, and security header middleware
+  - Awareness subsystem with Redis store and TTL cleanup
+  - ACK tracking with configurable retries
+  - Delta batching service with per-document coalescing
+  - Comprehensive test suite (711 tests)
 
 #### Storage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,10 +109,11 @@ Help us improve test coverage!
 
 ### 🌐 Multi-Language Servers
 
-Python and Go server implementations are complete and production-ready in v0.3.0. We welcome contributions to the **Rust server**:
+Python, Go, and C# server implementations are complete and production-ready in v0.3.0. We welcome contributions to the **Rust server**:
 
 - ✅ **Python Server** - Complete (FastAPI, JWT, PostgreSQL, Redis)
 - ✅ **Go Server** - Complete (gorilla/websocket, JWT, PostgreSQL, Redis)
+- ✅ **C# Server** - Complete (ASP.NET Core, JWT, PostgreSQL, Redis)
 - 🚧 **Rust Server** - Contributions welcome!
 
 **Requirements for Rust server:**

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -142,18 +142,29 @@ server/
 │   ├── tests/                  # Server tests (pytest)
 │   └── pyproject.toml          # Python project config
 │
-└── go/                         # Go server (v0.3.0+)
-    ├── cmd/server/main.go      # Entry point
-    ├── internal/
-    │   ├── config/             # Configuration
-    │   ├── auth/               # JWT validation
-    │   ├── security/           # Rate limiting, middleware
-    │   ├── storage/            # PostgreSQL adapter
-    │   ├── server/             # HTTP/WebSocket server
-    │   └── websocket/          # Connection management
-    └── go.mod                  # Go module file
-
-Note: Rust server implementation planned for a future release.
+├── go/                         # Go server (v0.3.0+)
+│   ├── cmd/server/main.go      # Entry point
+│   ├── internal/
+│   │   ├── config/             # Configuration
+│   │   ├── auth/               # JWT validation
+│   │   ├── security/           # Rate limiting, middleware
+│   │   ├── storage/            # PostgreSQL adapter
+│   │   ├── server/             # HTTP/WebSocket server
+│   │   └── websocket/          # Connection management
+│   └── go.mod                  # Go module file
+│
+└── csharp/                     # C# server (community-contributed)
+    ├── src/SyncKit.Server/     # ASP.NET Core server
+    │   ├── Program.cs          # Entry point
+    │   ├── Configuration/      # SyncKitConfig
+    │   ├── Auth/               # JWT auth, API keys, RBAC
+    │   ├── Security/           # Rate limiting, headers
+    │   ├── Storage/            # PostgreSQL adapter
+    │   ├── Sync/               # Document store, vector clocks
+    │   ├── WebSockets/         # Connection management, protocol
+    │   └── Awareness/          # Presence tracking
+    ├── src/SyncKit.Server.Tests/ # Test suite (711 tests)
+    └── src/SyncKit.Server.sln  # Solution file
 ```
 
 **Key Responsibilities:**

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Open source and self-hostable. No vendor lock-in, no surprise $2,000/month bills
 ### 🛡️ **Data Integrity Guaranteed**
 - Zero data loss with automatic conflict resolution (Last-Write-Wins)
 - Formal verification with TLA+ (3 bugs found and fixed)
-- 1,415+ comprehensive tests across TypeScript, Rust, Python, and Go (unit, integration, chaos, load)
+- 2,100+ comprehensive tests across TypeScript, Rust, Python, Go, and C# (unit, integration, chaos, load)
 
 ---
 
@@ -228,7 +228,7 @@ graph TD
 
     C --> D[IndexedDB Storage<br/>Your local source of truth]
 
-    D -.->|Optional| E[SyncKit Server<br/>TypeScript/Python/Go/Rust]
+    D -.->|Optional| E[SyncKit Server<br/>TypeScript/Python/Go/C#]
 
     E -->|Real-time sync| E1[WebSocket]
     E -->|Persistence| E2[PostgreSQL/MongoDB]
@@ -367,6 +367,7 @@ Different libraries make different trade-offs. Here's how SyncKit compares:
 - **`@synckit-js/server`** - Bun + Hono TypeScript server (production-ready)
 - **Python Server** - FastAPI implementation (production-ready, v0.3.0)
 - **Go Server** - High-performance goroutine-based server (production-ready, v0.3.0)
+- **C# Server** - ASP.NET Core implementation (production-ready, community-contributed)
 
 ---
 
@@ -388,7 +389,7 @@ The core sync engine is battle-tested and ready for production:
 - ✅ **WASM Compilation** - 154KB gzipped (46KB lite), optimized performance
 - ✅ **TypeScript SDK** - Document, Text, RichText, Counter, Set APIs
 - ✅ **Storage Adapters** - IndexedDB, Memory, and OPFS
-- ✅ **Multi-Language Servers** - TypeScript, Python, and Go (all production-ready)
+- ✅ **Multi-Language Servers** - TypeScript, Python, Go, and C# (all production-ready)
 - ✅ **Undo/Redo** - Cross-tab undo with persistent history
 - ✅ **Awareness & Presence** - Real-time user tracking with cursor sharing
 - ✅ **Cross-Tab Sync** - BroadcastChannel-based synchronization
@@ -396,7 +397,7 @@ The core sync engine is battle-tested and ready for production:
 - ✅ **Quill Integration** - QuillBinding for Quill editor
 - ✅ **Snapshot API** - Document snapshots with automatic scheduling
 - ✅ **Benchmark Suite** - Cross-server performance comparison
-- ✅ **1,415+ Tests** - 100% pass rate across TypeScript, Rust, Python, and Go
+- ✅ **2,100+ Tests** - 100% pass rate across TypeScript, Rust, Python, Go, and C#
 - ✅ **Example Applications** - Todo app, collaborative editor, project management
 
 ### What's Next 🚧

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1063,7 +1063,7 @@ Each phase is complete when:
 |---------|----------|--------|--------------|
 | v0.1.0 | Nov 2025 | ✅ Complete | Foundation, LWW Sync, TypeScript SDK |
 | v0.2.0 | Dec 2025 | ✅ Complete | Collaborative Editing, Rich Text |
-| v0.3.0 | Feb 2026 | ✅ Complete | Multi-Language Servers, OPFS, Benchmarks |
+| v0.3.0 | Feb 2026 | ✅ Complete | Multi-Language Servers (TS, Python, Go, C#), OPFS, Benchmarks |
 | v0.4.0+ | 2026 | 📋 Planned | SQL Sync, Advanced Features |
 
 ---

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 # SyncKit Benchmark Suite
 
-Comprehensive performance benchmarks comparing TypeScript, Python, and Go server implementations.
+Comprehensive performance benchmarks comparing TypeScript, Python, and Go server implementations. The C# server includes its own BenchmarkDotNet suite in `server/csharp/src/SyncKit.Server.Benchmarks/`.
 
 ## Quick Start
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,16 +8,17 @@ Welcome to SyncKit! Build collaborative, offline-first apps without the complexi
 
 **Production-ready multi-language servers with comprehensive security.**
 
-v0.3.0 brings full server parity across TypeScript, Python, and Go:
+v0.3.0 brings full server parity across TypeScript, Python, Go, and C#:
 
 - **🐍 Python Server** - FastAPI with JWT, PostgreSQL, Redis pub/sub
 - **🐹 Go Server** - High-performance goroutine-based WebSocket server
+- **🔷 C# Server** - ASP.NET Core with JWT, PostgreSQL, Redis pub/sub
 - **💾 OPFS Storage** - 4-30x faster than IndexedDB for browser storage
 - **🔒 Security Hardening** - SQL injection prevention, JWT enforcement, rate limiting
 - **📸 Snapshot API** - Document snapshots with automatic scheduling
 - **📊 Benchmark Suite** - Cross-server performance comparison
 
-**Backed by 1,415+ passing tests** across TypeScript, Rust, Python, and Go. Production-ready.
+**Backed by 2,100+ passing tests** across TypeScript, Rust, Python, Go, and C#. Production-ready.
 
 **[Get started in 5 minutes →](guides/getting-started.md)**
 
@@ -158,7 +159,7 @@ Learn from working examples:
 - Network sync: 10-50ms p95 (faster than most REST APIs)
 - Multi-client convergence: <100ms (real-time collaboration)
 
-**Stress-tested:** 24-hour continuous operation, 1,415+ tests, zero memory leaks.
+**Stress-tested:** 14-day continuous operation (1.2M+ operations), 2,100+ tests.
 
 **[Learn more about performance →](guides/performance.md)** | **[Bundle size optimization →](guides/bundle-size-optimization.md)**
 
@@ -251,7 +252,7 @@ We welcome contributions!
 
 ### What's Complete ✅
 
-- ✅ **Multi-Language Servers** - TypeScript, Python, and Go (all production-ready)
+- ✅ **Multi-Language Servers** - TypeScript, Python, Go, and C# (all production-ready)
 - ✅ **OPFS Storage** - 4-30x faster browser storage with IndexedDB fallback
 - ✅ **Snapshot API** - Document snapshots with automatic scheduling
 - ✅ **Benchmark Suite** - Cross-server performance comparison
@@ -267,7 +268,7 @@ We welcome contributions!
 - ✅ Network sync layer (WebSocket, offline queue, auto-reconnect)
 - ✅ Cross-tab sync (BroadcastChannel + server-mediated)
 - ✅ Example applications (todo app, collaborative editor, project management)
-- ✅ **1,415+ tests** across TypeScript, Rust, Python, and Go
+- ✅ **2,100+ tests** across TypeScript, Rust, Python, Go, and C#
 - ✅ Formal verification (TLA+, 118K states explored)
 
 ### What's Next 🚧

--- a/docs/api/SDK_API.md
+++ b/docs/api/SDK_API.md
@@ -7,7 +7,7 @@
 
 ## ✅ v0.3.0 - Production Ready
 
-**SyncKit v0.3.0 is production-ready with multi-language servers (TypeScript, Python, Go), OPFS storage, and comprehensive security hardening.**
+**SyncKit v0.3.0 is production-ready with multi-language servers (TypeScript, Python, Go, C#), OPFS storage, and comprehensive security hardening.**
 
 ### What's New in v0.3.0
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -33,7 +33,7 @@ SyncKit is a **local-first sync engine** designed for modern web and mobile appl
 - 📦 **Production Bundle**: 154KB gzipped (46KB lite) - Complete solution with all collaboration features
 - 🌐 **Universal**: Works everywhere (browser, Node.js, mobile, desktop)
 - 🔒 **Data Integrity**: Formally verified with TLA+ (zero data loss guarantee)
-- 🧪 **Battle-Tested**: 1,415+ passing tests across TypeScript, Rust, Python, and Go
+- 🧪 **Battle-Tested**: 2,100+ passing tests across TypeScript, Rust, Python, Go, and C#
 
 **Target Use Cases:**
 - Collaborative applications (Google Docs-style)
@@ -794,4 +794,4 @@ SyncKit's architecture is designed for **performance**, **correctness**, and **s
 ✅ **Scalability:** Horizontal scaling + partial sync = millions of users
 ✅ **Security:** JWT + RBAC + TLS = production-ready security
 
-**Implementation Status:** All core architecture components implemented and production-verified. Includes cross-tab synchronization via BroadcastChannel API, Vue 3/Svelte 5 framework adapters, OPFS storage, Text/Counter/Set CRDT APIs exposed in SDK, and multi-language server implementations (TypeScript, Python, Go). Future enhancements: Protobuf protocol, SQLite storage, Rust server.
+**Implementation Status:** All core architecture components implemented and production-verified. Includes cross-tab synchronization via BroadcastChannel API, Vue 3/Svelte 5 framework adapters, OPFS storage, Text/Counter/Set CRDT APIs exposed in SDK, and multi-language server implementations (TypeScript, Python, Go, C#). Future enhancements: Protobuf protocol, SQLite storage, Rust server.

--- a/docs/benchmarks/server-results.md
+++ b/docs/benchmarks/server-results.md
@@ -4,9 +4,11 @@
 **Date:** February 2026
 **Servers Tested:** TypeScript, Python, Go
 
+> **Note:** The C# server (ASP.NET Core) is also production-ready but was not included in these benchmarks. It ships with its own BenchmarkDotNet suite in `server/csharp/src/SyncKit.Server.Benchmarks/`. Cross-server comparison results for C# will be added in a future update.
+
 ## Executive Summary
 
-All three SyncKit server implementations (TypeScript, Python, Go) are production-ready with excellent performance characteristics:
+All three benchmarked SyncKit server implementations (TypeScript, Python, Go) are production-ready with excellent performance characteristics:
 
 - **Go** leads in raw throughput (~1,200 ops/sec) and lowest latency
 - **TypeScript** provides balanced performance (~800 ops/sec) with the richest ecosystem
@@ -145,6 +147,6 @@ bun run benchmarks/run-benchmarks.ts --all --output results.json
 
 ## Conclusion
 
-SyncKit v0.3.0 delivers production-ready performance across all three server implementations. Choose based on your team's expertise and infrastructure requirements rather than raw performance—all servers exceed typical real-time collaboration requirements.
+SyncKit v0.3.0 delivers production-ready performance across all benchmarked server implementations. Choose based on your team's expertise and infrastructure requirements rather than raw performance -- all servers exceed typical real-time collaboration requirements. The C# server is also available for .NET teams.
 
 For most teams, **TypeScript** offers the best balance of performance, ecosystem, and developer experience. Teams with high-throughput requirements or Go expertise should consider the **Go** implementation.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -6,7 +6,7 @@ SyncKit is a production-ready sync engine that makes building local-first applic
 
 > **What you'll build:** A todo app that works offline, persists data locally, and syncs in real-time with a server—in just 5 minutes.
 >
-> **v0.3.0 includes:** Multi-language servers (TypeScript, Python, Go), OPFS storage, snapshot API, security hardening, plus text editing (Fugue), rich text (Peritext), undo/redo, presence tracking, cursor sharing, counters, sets, and framework adapters for React, Vue 3, and Svelte 5.
+> **v0.3.0 includes:** Multi-language servers (TypeScript, Python, Go, C#), OPFS storage, snapshot API, security hardening, plus text editing (Fugue), rich text (Peritext), undo/redo, presence tracking, cursor sharing, counters, sets, and framework adapters for React, Vue 3, and Svelte 5.
 
 ---
 

--- a/sdk/PERFORMANCE.md
+++ b/sdk/PERFORMANCE.md
@@ -95,7 +95,7 @@ All sizes are **gzipped** for fair comparison:
 
 ## Test Coverage
 
-- **Total tests**: 1,415+ across TypeScript, Rust, Python, and Go
+- **Total tests**: 2,100+ across TypeScript, Rust, Python, Go, and C#
 - **Unit tests**: 100% passing ✅
 - **Integration tests**: 100% passing ✅
 - **Performance tests**: All passing ✅
@@ -113,7 +113,7 @@ npm test -- performance/benchmarks.test.ts --run
 ## Version History
 
 ### v0.3.0 (Current)
-- Multi-language server implementations (TypeScript, Python, Go)
+- Multi-language server implementations (TypeScript, Python, Go, C#)
 - OPFS storage adapter (4-30x faster than IndexedDB)
 - Comprehensive benchmark suite
 - Performance benchmarks established

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -713,9 +713,10 @@ console.log(state.pendingOps)    // Operations waiting to sync
 - ✅ TypeScript reference server (Bun + Hono)
 - ✅ Python server (FastAPI + WebSockets)
 - ✅ Go server (Gorilla WebSocket)
+- ✅ C# server (ASP.NET Core)
 
 **Test Coverage:**
-- ✅ 1,415+ comprehensive tests across TypeScript, Rust, Python, and Go
+- ✅ 2,100+ comprehensive tests across TypeScript, Rust, Python, Go, and C#
 - ✅ 87% code coverage
 - ✅ Unit, integration, chaos, and load tests
 


### PR DESCRIPTION
## Summary
- Update 13 documentation files to reflect the community-contributed C# server (PR #94)
- Update test count from 1,415+ to 2,100+ (711 C# tests added)
- Add C# server entry to CHANGELOG v0.3.0 section with full feature list
- Add server/csharp/ directory structure to PROJECT_STRUCTURE.md
- Note C# availability in benchmark docs without fabricating comparison data
- Fix stress test claim to accurate 14-day continuous operation figure

## Test plan
- [x] Grep confirms no remaining "1,415" references
- [x] Grep confirms no "TypeScript, Python, and Go" without C# (except benchmark-specific context)
- [x] Grep confirms no inaccurate stress test claims