### PR TITLE
fix(csharp): remove Aspire code references and fix formatting

### DIFF
--- a/server/csharp/src/SyncKit.Server/Program.cs
+++ b/server/csharp/src/SyncKit.Server/Program.cs
@@ -100,14 +100,6 @@ try
         Log.Information("Using SYNCKIT_SERVER_URL: {Url}", httpUrl);
     }
 
-    // Add Aspire service defaults when running under Aspire orchestration
-    // This provides OpenTelemetry, service discovery, and resilience patterns
-    var isAspireManaged = !string.IsNullOrEmpty(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
-    if (isAspireManaged)
-    {
-        builder.AddServiceDefaults();
-        Log.Information("Running under Aspire orchestration - service defaults enabled");
-    }
 
     // Configure Serilog from appsettings.json
     builder.Host.UseSerilog((context, services, configuration) => configuration
@@ -235,11 +227,6 @@ try
     // Enable WebSocket support with SyncKit middleware
     app.UseSyncKitWebSockets();
 
-    // Map Aspire default endpoints when running under orchestration
-    if (isAspireManaged)
-    {
-        app.MapDefaultEndpoints();
-    }
 
     // Attempt to connect storage provider; FallbackStorageAdapter handles degradation
     var storage = app.Services.GetRequiredService<IStorageAdapter>();

--- a/server/csharp/src/SyncKit.Server/Services/PerformanceMetrics.cs
+++ b/server/csharp/src/SyncKit.Server/Services/PerformanceMetrics.cs
@@ -113,7 +113,8 @@ public static class PerformanceMetrics
         do
         {
             currentMax = Interlocked.Read(ref _maxBroadcastLatencyMs);
-            if (milliseconds <= currentMax) break;
+            if (milliseconds <= currentMax)
+                break;
         } while (Interlocked.CompareExchange(ref _maxBroadcastLatencyMs, milliseconds, currentMax) != currentMax);
     }
 
@@ -129,7 +130,8 @@ public static class PerformanceMetrics
         do
         {
             currentMax = Interlocked.Read(ref _maxProcessingLatencyMs);
-            if (milliseconds <= currentMax) break;
+            if (milliseconds <= currentMax)
+                break;
         } while (Interlocked.CompareExchange(ref _maxProcessingLatencyMs, milliseconds, currentMax) != currentMax);
     }
 
@@ -150,7 +152,8 @@ public static class PerformanceMetrics
         do
         {
             currentMax = Interlocked.Read(ref _maxQueueDepth);
-            if (depth <= currentMax) break;
+            if (depth <= currentMax)
+                break;
         } while (Interlocked.CompareExchange(ref _maxQueueDepth, depth, currentMax) != currentMax);
     }
 
@@ -173,21 +176,24 @@ public static class PerformanceMetrics
         do
         {
             currentMax = Interlocked.Read(ref _maxSerializeTimeUs);
-            if (serializeUs <= currentMax) break;
+            if (serializeUs <= currentMax)
+                break;
         } while (Interlocked.CompareExchange(ref _maxSerializeTimeUs, serializeUs, currentMax) != currentMax);
 
         // Track max semaphore wait time
         do
         {
             currentMax = Interlocked.Read(ref _maxSemaphoreWaitTimeUs);
-            if (semaphoreWaitUs <= currentMax) break;
+            if (semaphoreWaitUs <= currentMax)
+                break;
         } while (Interlocked.CompareExchange(ref _maxSemaphoreWaitTimeUs, semaphoreWaitUs, currentMax) != currentMax);
 
         // Track max websocket send time
         do
         {
             currentMax = Interlocked.Read(ref _maxWebSocketSendTimeUs);
-            if (webSocketSendUs <= currentMax) break;
+            if (webSocketSendUs <= currentMax)
+                break;
         } while (Interlocked.CompareExchange(ref _maxWebSocketSendTimeUs, webSocketSendUs, currentMax) != currentMax);
     }
 
@@ -203,7 +209,8 @@ public static class PerformanceMetrics
         do
         {
             currentMax = Interlocked.Read(ref _maxPendingSends);
-            if (current <= currentMax) break;
+            if (current <= currentMax)
+                break;
         } while (Interlocked.CompareExchange(ref _maxPendingSends, current, currentMax) != currentMax);
     }
 


### PR DESCRIPTION
## Summary
- Remove AddServiceDefaults() and MapDefaultEndpoints() calls from Program.cs that referenced the removed Aspire ServiceDefaults project
- Fix whitespace formatting in PerformanceMetrics.cs (break statements on separate lines)

## Test plan
- [ ] C# CI Build & Test should pass
- [ ] C# CI Format Check should pass