### PR TITLE
fix(csharp): resolve remaining CI failures for Docker, Postgres tests, and formatting

### DIFF
--- a/server/csharp/src/Dockerfile
+++ b/server/csharp/src/Dockerfile
@@ -23,6 +23,7 @@ COPY SyncKit.Server.sln .
 COPY Directory.Build.props .
 COPY SyncKit.Server/SyncKit.Server.csproj SyncKit.Server/
 COPY SyncKit.Server.Tests/SyncKit.Server.Tests.csproj SyncKit.Server.Tests/
+COPY SyncKit.Server.Benchmarks/SyncKit.Server.Benchmarks.csproj SyncKit.Server.Benchmarks/
 
 # Restore dependencies (cached unless project files change)
 RUN dotnet restore SyncKit.Server.sln
@@ -30,6 +31,7 @@ RUN dotnet restore SyncKit.Server.sln
 # Copy source code
 COPY SyncKit.Server/ SyncKit.Server/
 COPY SyncKit.Server.Tests/ SyncKit.Server.Tests/
+COPY SyncKit.Server.Benchmarks/ SyncKit.Server.Benchmarks/
 
 # Build and publish release version
 WORKDIR /src/SyncKit.Server

--- a/server/csharp/src/SyncKit.Server.Tests/Storage/PostgresStorageAdapterTests.cs
+++ b/server/csharp/src/SyncKit.Server.Tests/Storage/PostgresStorageAdapterTests.cs
@@ -47,7 +47,7 @@ public class PostgresStorageAdapterTests : IAsyncLifetime
         _connectionString = $"Host={host};Port={port};Username=synckit;Password=synckit_test;Database=synckit_test";
 
         // Apply schema.sql
-        var schema = File.ReadAllText(Path.Combine("..", "..", "..", "..", "..", "server", "typescript", "src", "storage", "schema.sql"));
+        var schema = File.ReadAllText(Path.Combine("..", "..", "..", "..", "..", "..", "..", "server", "typescript", "src", "storage", "schema.sql"));
         await using var conn = new NpgsqlConnection(_connectionString);
         await conn.OpenAsync();
         await using var cmd = conn.CreateCommand();

--- a/server/csharp/src/SyncKit.Server.Tests/Sync/LwwConflictResolutionTests.cs
+++ b/server/csharp/src/SyncKit.Server.Tests/Sync/LwwConflictResolutionTests.cs
@@ -341,7 +341,9 @@ public class LwwConflictResolutionTests
         // Rebuild from constructor
         var clock = new VectorClock(new Dictionary<string, long>
         {
-            ["clientA"] = 2, ["clientB"] = 1, ["clientC"] = 1
+            ["clientA"] = 2,
+            ["clientB"] = 1,
+            ["clientC"] = 1
         });
         var docRebuilt = new Document("doc-1", clock, deltas);
         var stateRebuilt = docRebuilt.BuildState();
@@ -375,7 +377,9 @@ public class LwwConflictResolutionTests
 
         var clock = new VectorClock(new Dictionary<string, long>
         {
-            ["clientA"] = 1, ["clientB"] = 1, ["clientC"] = 1
+            ["clientA"] = 1,
+            ["clientB"] = 1,
+            ["clientC"] = 1
         });
         var docRebuilt = new Document("doc-1", clock, deltas);
 
@@ -459,10 +463,12 @@ public class LwwConflictResolutionTests
 
         // Try forward and reverse ordering
         var doc1 = new Document("doc-1");
-        foreach (var d in deltas) doc1.AddDelta(d);
+        foreach (var d in deltas)
+            doc1.AddDelta(d);
 
         var doc2 = new Document("doc-2");
-        foreach (var d in deltas.AsEnumerable().Reverse()) doc2.AddDelta(d);
+        foreach (var d in deltas.AsEnumerable().Reverse())
+            doc2.AddDelta(d);
 
         var state1 = doc1.BuildState();
         var state2 = doc2.BuildState();

--- a/server/csharp/src/SyncKit.Server.Tests/WebSockets/Handlers/DeltaMessageHandlerTests.cs
+++ b/server/csharp/src/SyncKit.Server.Tests/WebSockets/Handlers/DeltaMessageHandlerTests.cs
@@ -78,7 +78,7 @@ public class DeltaMessageHandlerTests
         _mockCoordinator.Verify(c => c.ApplyDeltaAsync(
             documentId,
             It.IsAny<System.Text.Json.JsonElement>(),
-            It.IsAny<Dictionary<string,long>>(),
+            It.IsAny<Dictionary<string, long>>(),
             It.IsAny<long>(),
             It.Is<string>(id => id == clientId),
             It.IsAny<string>()),
@@ -294,7 +294,7 @@ public class DeltaMessageHandlerTests
 
         SetupAuthenticatedConnectionWithWriteAccess(connectionId, clientId, subscriptions, documentId);
 
-        Dictionary<string,long>? capturedVectorClock = null;
+        Dictionary<string, long>? capturedVectorClock = null;
         _mockCoordinator.Setup(c => c.ApplyDeltaAsync(
                 It.IsAny<string>(),
                 It.IsAny<System.Text.Json.JsonElement>(),
@@ -302,9 +302,9 @@ public class DeltaMessageHandlerTests
                 It.IsAny<long>(),
                 It.IsAny<string>(),
                 It.IsAny<string>()))
-            .Callback<string, System.Text.Json.JsonElement, Dictionary<string,long>, long, string, string>((docId, deltaJson, vc, ts, clientId, deltaId) =>
+            .Callback<string, System.Text.Json.JsonElement, Dictionary<string, long>, long, string, string>((docId, deltaJson, vc, ts, clientId, deltaId) =>
             {
-                capturedVectorClock = vc == null ? null : new Dictionary<string,long>(vc);
+                capturedVectorClock = vc == null ? null : new Dictionary<string, long>(vc);
             })
             .ReturnsAsync(new Dictionary<string, object?> { { "field", "value" } });
         _mockConnectionManager.Setup(cm => cm.BroadcastToDocumentAsync(
@@ -348,7 +348,7 @@ public class DeltaMessageHandlerTests
                 It.IsAny<long>(),
                 It.IsAny<string>(),
                 It.IsAny<string>()))
-            .Callback<string, System.Text.Json.JsonElement, Dictionary<string,long>, long, string, string>((docId, deltaJson, vc, ts, clientId, deltaId) =>
+            .Callback<string, System.Text.Json.JsonElement, Dictionary<string, long>, long, string, string>((docId, deltaJson, vc, ts, clientId, deltaId) =>
             {
                 capturedClientId = clientId;
             })
@@ -645,7 +645,7 @@ public class DeltaMessageHandlerTests
         _mockCoordinator.Verify(c => c.ApplyDeltaAsync(
             documentId,
             It.IsAny<System.Text.Json.JsonElement>(),
-            It.IsAny<Dictionary<string,long>>(),
+            It.IsAny<Dictionary<string, long>>(),
             It.IsAny<long>(),
             It.Is<string>(id => id == "admin-client"),
             It.IsAny<string>()), Times.Once);

--- a/server/csharp/src/SyncKit.Server/Services/PerformanceMetrics.cs
+++ b/server/csharp/src/SyncKit.Server/Services/PerformanceMetrics.cs
@@ -5,7 +5,7 @@ namespace SyncKit.Server.Services;
 /// <summary>
 /// Centralized performance metrics for delta tracking and convergence analysis.
 /// These metrics help diagnose the 40% convergence gap between C# and TypeScript servers.
-/// 
+///
 /// Key metrics:
 /// - DeltasReceived: Deltas received from clients
 /// - DeltasBroadcast: Deltas sent to subscribers (fan-out count)
@@ -203,7 +203,7 @@ public static class PerformanceMetrics
     public static void IncrementPendingSends()
     {
         var current = Interlocked.Increment(ref _pendingSends);
-        
+
         // Track max
         long currentMax;
         do
@@ -248,7 +248,7 @@ public static class PerformanceMetrics
         var queueDepthSamples = Interlocked.Read(ref _totalQueueDepthSamples);
         var totalQueueDepth = Interlocked.Read(ref _totalQueueDepth);
         var maxQueueDepth = Interlocked.Read(ref _maxQueueDepth);
-        
+
         // Send timing breakdown
         var sendTimingSamples = Interlocked.Read(ref _sendTimingSamples);
         var totalSerializeUs = Interlocked.Read(ref _totalSerializeTimeUs);

--- a/server/csharp/src/SyncKit.Server/Sync/Experiments/SingleThreadedCoordinator.cs
+++ b/server/csharp/src/SyncKit.Server/Sync/Experiments/SingleThreadedCoordinator.cs
@@ -334,7 +334,8 @@ public class SingleThreadDocument
 
     public IReadOnlyList<StoredDelta> GetDeltasSince(VectorClock? since)
     {
-        if (since == null) return _deltas.ToList();
+        if (since == null)
+            return _deltas.ToList();
         return _deltas.Where(d => !d.VectorClock.HappensBefore(since) && !d.VectorClock.Equals(since)).ToList();
     }
 

--- a/server/csharp/src/SyncKit.Server/SyncKit.Server.csproj
+++ b/server/csharp/src/SyncKit.Server/SyncKit.Server.csproj
@@ -16,8 +16,5 @@
     <PackageReference Include="StackExchange.Redis" Version="2.8.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\orchestration\aspire\SyncKit.ServiceDefaults\SyncKit.ServiceDefaults.csproj" />
-  </ItemGroup>
 
 </Project>

--- a/server/csharp/src/SyncKit.Server/WebSockets/ConnectionManager.cs
+++ b/server/csharp/src/SyncKit.Server/WebSockets/ConnectionManager.cs
@@ -312,7 +312,8 @@ public class ConnectionManager : IConnectionManager
         do
         {
             currentMax = Interlocked.Read(ref _maxBroadcastTimeMs);
-            if (elapsedMs <= currentMax) break;
+            if (elapsedMs <= currentMax)
+                break;
         } while (Interlocked.CompareExchange(ref _maxBroadcastTimeMs, elapsedMs, currentMax) != currentMax);
 
         // Log timing breakdown for broadcasts that take > 1ms


### PR DESCRIPTION
## Summary

Fixes the 3 remaining actionable CI failures on PR #102 (release PR):

- **Format Check**: Remove stale Aspire `ProjectReference` from `.csproj` (missed in #103/#104), fix trailing whitespace on blank lines across 6 files, split single-line `if/break/return/foreach` patterns, add missing spaces in `Dictionary<string, long>` generics
- **Docker Build**: Add `SyncKit.Server.Benchmarks` csproj to Dockerfile so `dotnet restore` can resolve all solution references
- **Integration Tests (Postgres)**: Fix relative path to `schema.sql` — test DLL runs from `bin/Release/net10.0/`, needs 7 parent directories (not 5) to reach repo root

## Test plan
- [ ] Format Check job passes
- [ ] Docker Build job passes
- [ ] Integration Tests (Postgres) job passes
- [ ] Build & Test job still passes