### PR TITLE
fix(csharp): fix E2E test path and Postgres health check container conflict

### DIFF
--- a/.github/workflows/dotnet-server.yml
+++ b/.github/workflows/dotnet-server.yml
@@ -184,8 +184,8 @@ jobs:
 
       - name: Start test environment and run e2e tests
         run: |
-          chmod +x server/csharp/src/run-tests.sh
-          server/csharp/src/run-tests.sh
+          chmod +x ./run-tests.sh
+          ./run-tests.sh
 
       - name: Upload E2E Artifacts
         uses: actions/upload-artifact@v4

--- a/server/csharp/src/SyncKit.Server.Tests/Health/PostgreSqlHealthCheckTests.cs
+++ b/server/csharp/src/SyncKit.Server.Tests/Health/PostgreSqlHealthCheckTests.cs
@@ -18,11 +18,11 @@ public class PostgreSqlHealthCheckTests : IAsyncLifetime
         _postgresContainer = new TestcontainersBuilder<TestcontainersContainer>()
             .WithImage("postgres:15")
             .WithCleanUp(true)
-            .WithName("synckit-test-postgres")
+            .WithName("synckit-test-postgres-health")
             .WithEnvironment("POSTGRES_USER", "synckit")
             .WithEnvironment("POSTGRES_PASSWORD", "synckit_test")
             .WithEnvironment("POSTGRES_DB", "synckit_test")
-            .WithPortBinding(54320, 5432)
+            .WithPortBinding(54321, 5432)
             .Build();
     }
 


### PR DESCRIPTION
## Summary

Fixes the last 2 CI failures on PR #102:

- **E2E JS Tests**: The workflow default `working-directory: server/csharp/src` caused the path `server/csharp/src/run-tests.sh` to resolve to `server/csharp/src/server/csharp/src/run-tests.sh`. Changed to `./run-tests.sh`
- **Integration Tests (Postgres)**: `PostgreSqlHealthCheckTests` and `PostgresStorageAdapterTests` both used container name `synckit-test-postgres` on port 54320, causing conflicts when xUnit runs both in the same session. Changed health check test to `synckit-test-postgres-health` on port 54321

## Test plan
- [ ] E2E JS Tests job no longer fails with "No such file or directory"
- [ ] Integration Tests (Postgres) — all 10 tests pass