### PR TITLE
fix(demo): allow typing "?" in editable areas

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -238,6 +238,8 @@ function AppContent() {
       }
       // Help (Shift+?)
       if (e.shiftKey && e.key === '?') {
+        const target = e.target as HTMLElement;
+        if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return;
         e.preventDefault();
         setShowHelpPanel(true);
       }


### PR DESCRIPTION
## Summary
- Skip the help panel keyboard shortcut (Shift+?) when the user is focused on an input, textarea, or contenteditable element

Fixes #109